### PR TITLE
Fix : le bouton « Vider » du Stock de base ne décochait rien

### DIFF
--- a/courses.html
+++ b/courses.html
@@ -2485,15 +2485,31 @@
       }
 
       function clearDrawer() {
+        // Le tiroir « Stock de base » n'utilise pas `selections` mais l'objet
+        // `stockBase` (currentCategory === null dans ce cas).
+        const isStock = currentCategory === null;
         showConfirmModal(
-          "Vider cette catégorie ?",
-          "Tous les items cochés de cette catégorie seront décochés.",
+          isStock ? "Vider le stock de base ?" : "Vider cette catégorie ?",
+          isStock
+            ? "Tous les produits du stock de base seront décochés."
+            : "Tous les items cochés de cette catégorie seront décochés.",
           () => {
-            Object.keys(selections[currentCategory]).forEach((item) => {
-              selections[currentCategory][item] = false;
-            });
-            openDrawer(currentCategory);
-            showToast("Catégorie vidée");
+            if (isStock) {
+              Object.keys(stockBase).forEach((item) => {
+                stockBase[item] = false;
+              });
+              localStorage.setItem("food_home_stock_base", JSON.stringify(stockBase));
+              openStockDrawer();
+              renderCategories();
+              showToast("Stock de base vidé");
+            } else {
+              Object.keys(selections[currentCategory]).forEach((item) => {
+                selections[currentCategory][item] = false;
+              });
+              saveToAPI();
+              openDrawer(currentCategory);
+              showToast("Catégorie vidée");
+            }
           }
         );
       }


### PR DESCRIPTION
## Problème

Dans le tiroir **📦 Stock de base**, cliquer sur **🗑️ Vider** puis **Confirmer** ne décochait aucun produit.

## Cause

`clearDrawer()` opérait sur `selections[currentCategory]`. Or le tiroir Stock de base est ouvert avec `currentCategory = null` et son état vit dans un objet **séparé** (`stockBase`, persisté sous `food_home_stock_base`). L'appel faisait donc `Object.keys(selections[null])` → exception → rien n'était décoché.

## Correctif

- `clearDrawer()` détecte le cas stock (`currentCategory === null`) : il réinitialise `stockBase`, persiste dans `localStorage`, puis re-render le tiroir et la liste.
- Bonus : ajout de `saveToAPI()` sur le vidage d'une catégorie normale, pour une persistance immédiate (comportement cohérent avec `clearAll()`).

## Vérification

Testé dans Chromium : stock avec Poivre + Farine cochés → « Vider » → **plus aucun produit coché** (localStorage + DOM), aucune erreur JS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017EeGcqWUiDk6iWYMKhXWFH)_