### PR TITLE
Planning famille : rythme semaine/we + étiquettes moment & public

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,10 +57,12 @@ chaînes) :
   "saisons": "toute",              // "toute" | "printemps" | "ete" | "automne" | "hiver"
   "diets": "equilibre|vegetarien", // valeurs séparées par « | »
   "proteine": "laitier",           // viande | poisson | oeuf | laitier | vegetal | ...
-  "kidsFriendly": "Oui",           // "Oui" | "Non"
+  "kidsFriendly": "Oui",           // "Oui" | "Non" (hérité, peu fiable — voir `public`)
   "temps": "50",                   // minutes (chaîne)
   "budget": "budget",              // "budget" | "moyen" | "eleve"
-  "categorie_jour": "",            // "" | "semaine" (usage planning)
+  "categorie_jour": "",            // "" | "semaine" (hérité, non utilisé par le planning)
+  "moment": "semaine",             // "semaine" | "we" | "tous" — quand servir la recette
+  "public": "kids",                // "kids" | "adultes" | "tous" — pour qui
   "ingredients": "Lait (1 L)|Œufs (5)|Sucre (100 g)", // items séparés par « | », quantité entre ( )
   "instructions": "Préchauffer le four à 180°C. …"    // texte libre
 }
@@ -69,6 +71,25 @@ chaînes) :
 Convention **ingrédients** : `Nom (quantité)` séparés par `|`. La quantité entre
 parenthèses est la donnée que l'utilisateur a récemment ajoutée à tout le
 catalogue.
+
+**Étiquettes `moment` / `public`** (présentes sur les 167 recettes). Ce sont les
+axes qui pilotent le générateur de planning et les badges des cartes
+(`public: kids` → 👶, `adultes` → 🍷, `moment: we` → 🗓️). `kidsFriendly` et
+`categorie_jour` restent dans le JSON pour compatibilité mais ne sont plus la
+source de vérité — utiliser `moment`/`public`.
+
+### Planning famille (`generateWeeklyPlanning` dans `eat.html`)
+
+Le planning couvre **9 repas**, définis dans la constante `PLANNING_SLOTS` :
+dîners Lun→Ven + déjeuner du mercredi (créneaux `kind:"semaine"`), puis samedi
+dîner + dimanche déjeuner & dîner (`kind:"we"`). Les midis d'école
+(Lun/Mar/Jeu/Ven) sont volontairement absents.
+
+- Créneaux **semaine** : plats tirés de `moment ∈ {semaine, tous}` **et**
+  `public ∈ {kids, tous}`, en privilégiant les plats rapides au déjeuner.
+- Créneaux **we** : plats de `moment ∈ {we, tous}` (tous publics), en
+  privilégiant les plus qualitatifs (budget `moyen`/`eleve` ou temps > 45 min).
+- Variété assurée par déduplication des `id` et plafond de 2 par `proteine`.
 
 ### Liste de courses
 

--- a/eat.html
+++ b/eat.html
@@ -352,7 +352,7 @@
           <button class="btn-close" id="btn-close-planning">×</button>
         </div>
         <div class="alert-info">
-          👨‍👩‍👧‍👦 Planning pour une famille de 4 (2 adultes + 2 enfants) - Lundi au Vendredi
+          👨‍👩‍👧‍👦 Dîners de la semaine + déjeuner du mercredi, et week-end plus gourmand (les midis d'école sont exclus)
         </div>
         <!-- 🎯 BOUTONS DÉPLACÉS EN HAUT en version compacte -->
         <div style="margin-bottom: 20px; display: flex; gap: 10px; flex-wrap: wrap; justify-content: center;">
@@ -380,8 +380,23 @@
       let allRecipes = [];
       let currentRecipe = null;
       let weeklyPlanning = {};
-      const DAYS = ["Lundi", "Mardi", "Mercredi", "Jeudi", "Vendredi"];
+      const DAYS = ["Lundi", "Mardi", "Mercredi", "Jeudi", "Vendredi", "Samedi", "Dimanche"];
       const MEALS = ["dejeuner", "diner"];
+      // Créneaux réellement planifiés (les midis d'école Lun/Mar/Jeu/Ven sont
+      // volontairement absents : enfants à la cantine).
+      //  - kind "semaine" : plats simples/rapides, plutôt kids
+      //  - kind "we"      : plats plus qualitatifs, adultes possibles
+      const PLANNING_SLOTS = [
+        { day: "Lundi",    meal: "diner",    kind: "semaine" },
+        { day: "Mardi",    meal: "diner",    kind: "semaine" },
+        { day: "Mercredi", meal: "dejeuner", kind: "semaine" },
+        { day: "Mercredi", meal: "diner",    kind: "semaine" },
+        { day: "Jeudi",    meal: "diner",    kind: "semaine" },
+        { day: "Vendredi", meal: "diner",    kind: "semaine" },
+        { day: "Samedi",   meal: "diner",    kind: "we" },
+        { day: "Dimanche", meal: "dejeuner", kind: "we" },
+        { day: "Dimanche", meal: "diner",    kind: "we" },
+      ];
       // Elements DOM
       const searchInput = document.getElementById("search");
       const typeSelect = document.getElementById("type");
@@ -536,7 +551,9 @@
           <div class="recipe-meta">
             <span>⏱️ ${recipe.temps} min</span>
             <span>🥩 ${recipe.proteine}</span>
-            ${recipe.kidsFriendly === "Oui" ? "<span>👶 Kids</span>" : ""}
+            ${recipe.public === "kids" ? "<span>👶 Kids</span>" : ""}
+            ${recipe.public === "adultes" ? "<span>🍷 Adultes</span>" : ""}
+            ${recipe.moment === "we" ? "<span>🗓️ WE</span>" : ""}
           </div>
         `;
         return card;
@@ -555,55 +572,75 @@
       function generateWeeklyPlanning() {
         // Réinitialiser
         weeklyPlanning = {};
-        // Filtrer les recettes adaptées aux enfants et plats uniquement
-        const kidsRecipes = allRecipes.filter(
-          (r) => r.kidsFriendly === "Oui" && r.type_repas === "plat"
+
+        const plats = allRecipes.filter((r) => r.type_repas === "plat");
+
+        // Pool SEMAINE : plats semaine/tous, plutôt kids/tous
+        const semainePool = plats.filter(
+          (r) =>
+            (r.moment === "semaine" || r.moment === "tous") &&
+            (r.public === "kids" || r.public === "tous")
         );
-        if (kidsRecipes.length < 10) {
-          showToast("Pas assez de recettes adaptées aux enfants disponibles");
+        // Pool WEEK-END : plats we/tous, tous publics (adultes bienvenus)
+        const wePool = plats.filter(
+          (r) => r.moment === "we" || r.moment === "tous"
+        );
+
+        if (semainePool.length < 6 || wePool.length < 3) {
+          showToast("Pas assez de recettes étiquetées pour générer le planning");
           return;
         }
-        // Séparer par catégories
-        const quickRecipes = kidsRecipes.filter(
-          (r) => parseInt(r.temps) <= 30 || r.diets.includes("rapide")
-        );
-        const standardRecipes = kidsRecipes.filter(
-          (r) => parseInt(r.temps) > 30 && parseInt(r.temps) <= 60
-        );
-        // Tracker des protéines utilisées pour varier
+
+        // Variété : éviter les répétitions et limiter chaque protéine
         const usedProteins = {};
-        const selectedRecipes = [];
-        // Fonction pour sélectionner une recette avec variété
-        function selectRecipe(pool, preferQuick = false) {
-          const available = pool.filter(
+        const usedIds = new Set();
+
+        function pick(pool, { preferQuick = false, preferQuali = false } = {}) {
+          let avail = pool.filter(
             (r) =>
-              !selectedRecipes.includes(r.id) &&
+              !usedIds.has(r.id) &&
               (!usedProteins[r.proteine] || usedProteins[r.proteine] < 2)
           );
-          if (available.length === 0)
-            return pool[Math.floor(Math.random() * pool.length)];
-          const recipe =
-            available[Math.floor(Math.random() * available.length)];
-          selectedRecipes.push(recipe.id);
+          if (avail.length === 0) avail = pool.filter((r) => !usedIds.has(r.id));
+          if (avail.length === 0) avail = pool;
+
+          if (preferQuick) {
+            const quick = avail.filter(
+              (r) => parseInt(r.temps) <= 30 || r.diets.includes("rapide")
+            );
+            if (quick.length) avail = quick;
+          }
+          if (preferQuali) {
+            const quali = avail.filter(
+              (r) =>
+                r.budget === "moyen" ||
+                r.budget === "eleve" ||
+                parseInt(r.temps) > 45
+            );
+            if (quali.length) avail = quali;
+          }
+
+          const recipe = avail[Math.floor(Math.random() * avail.length)];
+          usedIds.add(recipe.id);
           usedProteins[recipe.proteine] =
             (usedProteins[recipe.proteine] || 0) + 1;
           return recipe;
         }
-        // Générer 10 repas (5 jours × 2 repas)
-        DAYS.forEach((day, dayIndex) => {
-          weeklyPlanning[day] = {};
-          // Déjeuner : privilégier les plats rapides
-          weeklyPlanning[day]["dejeuner"] = selectRecipe(
-            quickRecipes.length > 0 ? quickRecipes : kidsRecipes,
-            true
-          );
-          // Dîner : mixer rapides et standards
-          const dinnerPool =
-            dayIndex < 3 ? quickRecipes : [...quickRecipes, ...standardRecipes];
-          weeklyPlanning[day]["diner"] = selectRecipe(
-            dinnerPool.length > 0 ? dinnerPool : kidsRecipes
-          );
+
+        // Remplir chaque créneau selon son type
+        PLANNING_SLOTS.forEach((slot) => {
+          if (!weeklyPlanning[slot.day]) weeklyPlanning[slot.day] = {};
+          if (slot.kind === "we") {
+            weeklyPlanning[slot.day][slot.meal] = pick(wePool, {
+              preferQuali: true,
+            });
+          } else {
+            weeklyPlanning[slot.day][slot.meal] = pick(semainePool, {
+              preferQuick: slot.meal === "dejeuner",
+            });
+          }
         });
+
         // Afficher le planning
         renderWeeklyPlanning();
         planningModal.classList.add("active");
@@ -611,34 +648,41 @@
       function renderWeeklyPlanning() {
         weekGrid.innerHTML = "";
         DAYS.forEach((day) => {
+          const dayPlan = weeklyPlanning[day];
+          if (!dayPlan) return; // pas de créneau ce jour-là
+          const isWE = day === "Samedi" || day === "Dimanche";
+
+          let slotsHtml = "";
+          [
+            ["dejeuner", "☀️ Déjeuner"],
+            ["diner", "🌙 Dîner"],
+          ].forEach(([meal, label]) => {
+            const recipe = dayPlan[meal];
+            if (!recipe) return;
+            slotsHtml += `
+              <div class="meal-slot clickable" onclick="openRecipeFromPlanning('${day}', '${meal}')">
+                <div class="meal-label">${label}</div>
+                <div class="meal-content">${recipe.nom}</div>
+              </div>`;
+          });
+
+          const weBadge = isWE
+            ? ' <span style="font-size:11px;font-weight:700;color:#c26a1a;background:#fbecda;padding:2px 8px;border-radius:6px;vertical-align:middle;">WE</span>'
+            : "";
+
           const dayCard = document.createElement("div");
           dayCard.className = "day-card";
-          const dejeunerRecipe = weeklyPlanning[day]?.["dejeuner"];
-          const dinerRecipe = weeklyPlanning[day]?.["diner"];
           dayCard.innerHTML = `
-            <div class="day-name">${day}</div>
-           
-            <div class="meal-slot ${dejeunerRecipe ? 'clickable' : ''}" ${dejeunerRecipe ? `onclick="openRecipeFromPlanning('${day}', 'dejeuner')"` : ''}>
-              <div class="meal-label">☀️ Déjeuner</div>
-              <div class="meal-content">
-                ${dejeunerRecipe ? dejeunerRecipe.nom : "Aucune recette"}
-              </div>
-            </div>
-            <div class="meal-slot ${dinerRecipe ? 'clickable' : ''}" ${dinerRecipe ? `onclick="openRecipeFromPlanning('${day}', 'diner')"` : ''}>
-              <div class="meal-label">🌙 Dîner</div>
-              <div class="meal-content">
-                ${dinerRecipe ? dinerRecipe.nom : "Aucune recette"}
-              </div>
-            </div>
+            <div class="day-name">${day}${weBadge}</div>
+            ${slotsHtml}
           `;
           weekGrid.appendChild(dayCard);
         });
       }
       async function exportPlanningToShoppingList() {
         const allIngredients = new Set();
-        DAYS.forEach((day) => {
-          ["dejeuner", "diner"].forEach((meal) => {
-            const recipe = weeklyPlanning[day]?.[meal];
+        Object.values(weeklyPlanning).forEach((dayPlan) => {
+          Object.values(dayPlan).forEach((recipe) => {
             if (recipe) {
               recipe.ingredients.split("|").forEach((ing) => {
                 if (ing.trim()) allIngredients.add(ing.trim());

--- a/recipes.json
+++ b/recipes.json
@@ -11,7 +11,9 @@
     "ingredients": "Lait (1 L)|Œufs (5)|Sucre (100 g)|Fécule de maïs (60 g)|Vanille (1 gousse)|pâte brisée (230 g, optionnel)",
     "instructions": "Préchauffer le four à 180°C. Chauffer le lait avec la vanille. Fouetter les oeufs avec le sucre puis la fécule. Verser le lait chaud en fouettant, remettre sur feu doux et épaissir 1–2 min. Verser dans un moule (ou sur pâte brisée précuite 10 min). Cuire 35–40 min jusqu’à surface dorée. Refroidir complètement avant de couper.",
     "type_repas": "dessert",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "tous",
+    "public": "kids"
   },
   {
     "id": "p2",
@@ -25,7 +27,9 @@
     "ingredients": "Courgettes (400 g)|aubergine (300 g)|Tomates (400 g)|Oignons (2)|Ail (2 gousses)|Huile olive (3 c. s.)|Herbes de Provence (1 c. s.)|Sel, poivre (QS)",
     "instructions": "Préchauffer le four à 180°C. Émincer l’oignon et l’ail, les répartir au fond d’un plat huilé. Trancher courgettes, aubergines et tomates en rondelles, les disposer debout en alternant les couleurs. Arroser d’huile d’olive, saler/poivrer, parsemer d’herbes. Couvrir (papier alu) et cuire 35 min, découvrir et poursuivre 10–15 min pour dorer.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "tous",
+    "public": "tous"
   },
   {
     "id": "p3",
@@ -39,7 +43,9 @@
     "ingredients": "Feuilles de lasagnes (250 g)|Bœuf haché (500 g)|Oignons (1)|Ail (2 gousses)|Carottes (1 petite)|Tomates (400 g)|Concentré de tomate (1 c. s.)|Lait (500 ml)|Beurre (40 g)|Farine (40 g)|Sel, poivre (QS)|Fromage râpé (120 g)",
     "instructions": "Préparer la sauce tomate: faire revenir oignon, ail et carotte, ajouter le bœuf, puis tomates et concentré, mijoter 20 min. Préparer une béchamel: fondre le beurre, ajouter la farine, puis le lait au fouet jusqu’à épaississement",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "tous",
+    "public": "kids"
   },
   {
     "id": "p4",
@@ -53,7 +59,9 @@
     "ingredients": "Beurre (100 g)|Nectarines (700 g)|Menthe (QS)|Sucre (80 g)|Farine (150 g)",
     "instructions": "Eplucher ou laver les fruits, les couper en morceaux et les disposer dans un plat à gratin. Les parsemer des feuilles de menthe lavées et ciselées. Mélanger farine, cassonade et beurre pour obtenir une pâte sablonneuse et l'étaler sur les fruits sans tasser. Cuire à 200°C pendant 30mn environ. Servir froid ou tiède accompagné ou non de glace à la vanille.",
     "type_repas": "dessert",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "tous",
+    "public": "kids"
   },
   {
     "id": "p5",
@@ -67,7 +75,9 @@
     "ingredients": "Beurre (100 g)|Sucre (80 g)|Flocons d'avoine (100 g)|Rhubarbe (400 g)|Glaces (4 boules, optionnel)",
     "instructions": "Sortir le beurre du réfrigérateur. Préchauffer le four à 180°C. Éplucher et découper en tronçons de 1 cm la rhubarbe. Équeuter les fraises et les couper en quatre. Déposer les fruits dans deux plats individuels. Dans un saladier, bien mélanger avec les mains la farine, les flocons d’avoine, le sucre et le beurre ramolli en petits cubes. Vous devez obtenir une pâte grumeleuse. Émietter la pâte à crumble au-dessus des fruits de façon à les recouvrir. Enfourner environ 25 minutes à 180°C. Le crumble doit être doré. Déguster encore tiède avec une boule de glace.",
     "type_repas": "dessert",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "tous",
+    "public": "kids"
   },
   {
     "id": "p6",
@@ -81,7 +91,9 @@
     "ingredients": "Chocolats (150 g)|Poires (700 g)|Sucre (80 g)|Beurre (100 g)|Amandes (60 g)|Farine (150 g)",
     "instructions": "Mélanger, la farine, le beurre, la cassonade et la poudre d'amandes jusqu'à obtention d'une pâte sableuse. Mettre au frais pendant 30 mn. Beurrer un plat à four et y déposer les carrés de chocolat. Ébouillanter les poires 20 secondes, les peler et les couper en quartiers. Les placer sur les carrés de chocolat. Sortir la pâte du réfrigérateur et la répartir sur les poires et le chocolat. Mettre au four à th°C 6-7 pendant 30 mn. Servir tiède.",
     "type_repas": "dessert",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "tous",
+    "public": "kids"
   },
   {
     "id": "p7",
@@ -95,7 +107,9 @@
     "ingredients": "Lardons (150 g)|Beurre (30 g)|Vin rouge (500 ml)|Oignons (2)|Sel (QS)|Poivre (QS)|Bœuf (500 g)|Ail (2 gousses)|Bouquet garni (1)|Champignons (250 g)",
     "instructions": "Hacher les oignons. Peler l'ail. Dans une cocotte minute, faire roussir la viande et les lardons dans l’huile ou le beurre. Ajouter les oignons, les champignons égouttés et saupoudrer de fariner. Mélanger et laisser dorer un instant. Mouiller avec le vin rouge qui doit recouvrir la viande. Saler et poivrer. Ajouter l’ail et le bouquet garni. Fermer la cocotte minute. Laisser cuire doucement 60 min à partir de la mise en rotation de la soupape.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "we",
+    "public": "adultes"
   },
   {
     "id": "p8",
@@ -109,7 +123,9 @@
     "ingredients": "Huile (2 c. s.)|Filets de colin surgelés (500 g)|Lait (400 ml)|Ail (2 gousses)",
     "instructions": "Dans une sauteuse ou une poêle, faire chauffer à feu doux l'huile, l'ail pilé et les épices pendant 2 min. Déposer les filets de poisson congelés. Les retourner après 4 min, et verser le lait de coco. Remuer la sauce. C'est prêt !",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "tous",
+    "public": "tous"
   },
   {
     "id": "p9",
@@ -123,7 +139,9 @@
     "ingredients": "Sucre (80 g)|Beurre (100 g)|Mûres (700 g)|Farine (150 g)",
     "instructions": "Mélanger le sucre et la farine. Ajouter le beurre froid. Rouler entre les paumes. Disposer les mûres dans un plat, saupoudrer de sucre et de pâte. Enfourner 30 min.",
     "type_repas": "dessert",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "tous",
+    "public": "kids"
   },
   {
     "id": "p10",
@@ -137,7 +155,9 @@
     "ingredients": "Huile olive (3 c. s.)|Gingembre (2 cm)|Poivre (QS)|Sel (QS)|Coriandre (QS)|Thon (500 g)|Citron (1)|Ail (2 gousses)|Cumin (1 c. c.)",
     "instructions": "Quelques heures avant la grillade, mettre le thon dans un plat creux, puis l'arroser d'huile d'olive et du jus de citron. Presser l'ail, saupoudrer avec le cumin (une bonne cuillère à café). Râper le gingembre frais, saler et poivrer. Rajouter un peu de coriandre fraîche ou une dose de safran. Arroser souvent. Faire cuire au barbecue.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "we",
+    "public": "adultes"
   },
   {
     "id": "p11",
@@ -151,7 +171,9 @@
     "ingredients": "Quinoa (150 g)|Courgettes (200 g)|Poivrons (200 g)|Tomates (150 g)|Huile olive (2 c. s.)|Citron (1)|Herbes fraîches (basilic ou persil) (QS)|Sel, poivre (QS)",
     "instructions": "Cuire le quinoa selon les instructions. Griller les légumes au four ou à la poêle pendant 10-15 minutes. Mélanger avec le quinoa, arroser d’huile d’olive et de jus de citron. Assaisonner et servir frais.",
     "type_repas": "entree",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "semaine",
+    "public": "tous"
   },
   {
     "id": "p12",
@@ -165,7 +187,9 @@
     "ingredients": "Pizzas (2 pâtes)|Tomates (200 g)|mozzarella (250 g)|Tomates (300 g)|Basilic séché (1 c. c.)|Huile olive (2 c. s.)|Sel (QS)",
     "instructions": "Étaler la pâte à pizza sur une plaque. Étendre la sauce tomate, ajouter des tranches de mozzarella et de tomates. Arroser d’huile d’olive et cuire au four à 220°C pendant 15 minutes. Garnir de basilic frais avant de servir.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "semaine",
+    "public": "kids"
   },
   {
     "id": "p13",
@@ -179,7 +203,9 @@
     "ingredients": "Poulet (500 g)|Chapelure sans gluten (100 g)|Œufs (2)|Farine (60 g)|Huile olive (2 c. s.)|Sel, poivre (QS)",
     "instructions": "Couper le poulet en morceaux. Passer dans la farine, puis l’oeuf battu, et enfin la chapelure. Disposer sur une plaque huilée et cuire au four à 200°C pendant 15-20 minutes, en retournant à mi-cuisson. Servir avec une sauce au choix.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "semaine",
+    "public": "kids"
   },
   {
     "id": "p14",
@@ -193,7 +219,9 @@
     "ingredients": "Jambon Herta (4 tranches)|Bananes (2)|Beurre (30 g)|Brick (8 feuilles)|Gouda (8 tranches)",
     "instructions": "Préchauffer le four à 180°C (thermostat 6). Couper les bananes en deux dans la longueur et à nouveau en deux pour obtenir quatre morceaux. Envelopper chaque morceau d'une tranche de gouda puis d'une tranche de jambon. Mettre le tout dans une feuille de brick et rouler la feuille comme pour confectionner des nems. Mettre dans un plat à four et badigeonner d'un peu de beurre fondu. Enfourner pour 15 minutes de cuisson.",
     "type_repas": "entree",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "semaine",
+    "public": "kids"
   },
   {
     "id": "p15",
@@ -207,7 +235,9 @@
     "ingredients": "Huile d'arachide (3 c. s.)|Coriandre (1 bouquet)|Poivre (QS)|Sel (QS)|Poulet (500 g)|Nuoc mam (3 c. s.)|Citron (1)|Petit piment (1)|Ail (2 gousses)|Menthe (1 bouquet)|Choux (400 g)|Oignons (2)|Cacahuète grillée (60 g)",
     "instructions": "Faire légèrement pocher le poulet dans une casserole d'eau bouillante avec un bouillon de volaille, laisser frémir pendant 15 à 20 mn. sans couvrir. Egoutter le poulet. Refroidir et couper la viande en tranches fines. Dans un saladier, mélanger l'huile, le vinaigre, le nuoc-mam, le zeste et le jus du citron. Ajouter les piments épépinés, l'ail et le sucre. Mélanger et incorporer la menthe grossièrement ciselée et les deux tiers de la coriandre. Nettoyer, puis émincer finement le chou chinois et les oignons, râper grossièrement les carottes et mettre tous ces légumes dans le saladier, ainsi que le poulet. Saler et poivrer. Mélanger. Parsemer de cacahuètes grillées, grossièrement hâchées et du reste de coriandre. Servir frais.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "tous",
+    "public": "tous"
   },
   {
     "id": "p16",
@@ -221,7 +251,9 @@
     "ingredients": "poireaux (300 g)|Oignons (1)|Crème fraîche (200 g)|Beurre (60 g)|Veau (500 g)|Ail (2 gousses)|Échalotes (2)|céleri (1 branche)|1 bouquet garni|Citron (1)|Champignons (250 g)|Soupes (QS)|Œufs (2)",
     "instructions": "Pelez carotte, ail, échalotes et oignon. Hachez ce dernier ainsi que les blancs de poireaux. Coupez les échalotes et la carotte en deux. Portez à ébullition 2 litres d'eau dans un grand faitout, plongez-y les morceaux de viande pendant environ une minute pour les blanchir. Egouttez la viande, rincez-la sous l'eau froide et jetez l'eau de cuisson. Replacez la viande dans le faitout rincé. Ajoutez oignon et poireaux hachés, carottes, échalotes, ail, céleri et bouquet garni. Salez, poivrez et mouillez avec le vin. Ajoutez de l'eau pour que la viande et les légumes soient immergés. Couvrez. Portez à ébullition et laissez cuire 1 h 30. Faites cuire dans une poêle, avec 30 g de beurre, les champignons coupés et citronnés 10 min. Préparez un roux blond : faites fondre le reste de beurre dans une casserole, saupoudrez-le avec la farine, mélangez vivement au fouet, puis laissez refroidir. Quand la viande est cuite, mettez-la dans une passoire avec les légumes et récupérez le bouillon de cuisson. Délayez le roux avec ce bouillon et amenez à ébullition en fouettant. Remettez la viande et tous les légumes dans le faitout après avoir retiré bouquet garni, ail, céleri et carotte. Ajoutez les champignons, versez la sauce et réchauffez le tout 10 à 15 mn. Juste avant de servir mélangez la crème et les jaunes d'oeufs, incorporez-les à la sauce en tournant sans laisser bouillir. Ajoutez quelques gouttes de jus de citron. Servez dans un plat creux avec du persil.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "we",
+    "public": "adultes"
   },
   {
     "id": "p17",
@@ -235,7 +267,9 @@
     "ingredients": "Oignons (2)|Oranges (1)|Vin rouge corsé (500 ml)|Huile (2 c. s.)|Poivre (QS)|Sel (QS)|lapin (800 g)|Sel (QS)|Bouillon cube (1)|Bouquet garni (1)|Ail (2 gousses)|Eau (500 ml)",
     "instructions": "Salez, poivrez et farinez les morceaux de lapin. Pelez et émincez lez oignons, faites blanchir les lardons 2 mn à l'eau bouillante. Rafraîchissez et égouttez. Faites chauffer l'huile dans une cocotte. Faites y dorer les morceaux de lapin sur toutes les faces. Retirez les et remplacez-les par l'oignon. Laissez-les fondre 2 ou 3 mn. Ajoutez les lardons. Mélangez. Remettez les morceaux de lapins dans la cocotte. Mouillez avec le vin rouge et le bouillon. Ajoutez le zeste d'orange, le bouquet garni et l'ail écrasé. Laissez cuire 30 mn à couvert sur feu doux. Ajoutez alors les pruneaux. Poursuivez la cuisson 20 mn. Servir avec des tagliatelles fraîches.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "we",
+    "public": "adultes"
   },
   {
     "id": "p18",
@@ -249,7 +283,9 @@
     "ingredients": "Chocolats (200 g)|Bananes (3)|Sucre (80 g)|Pâtes (230 g)|Crème liquide (200 ml)|Œufs (2)|Lait (200 ml)",
     "instructions": "Préchauffez le four à 200°C (thermostat 6-7). Etalez la pâte sablée dans un plat à tarte. Faites fondre au micro-onde le chocolat pâtissier avec la crème liquide pendant 1min30. Etalez-le sur la pâte. Déposez les rondelles de bananes sur le chocolat. Mélangez les oeufs, le lait et le sucre en poudre ensemble, si vous avez un shaker, joignez-y ces ingrédients et agitez, c'est très efficace. Versez cette préparation sur les bananes. Mettez au four pendant 20 min.",
     "type_repas": "dessert",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "semaine",
+    "public": "kids"
   },
   {
     "id": "p19",
@@ -263,7 +299,9 @@
     "ingredients": "pâte feuilletée (230 g)|Jambon Herta (4 tranches)|Crème fraîche (200 g)|Blé (150 g)",
     "instructions": "Dérouler la pâte dans le moule et y mettre les tranches de jambon, étaler la crème avec la cuillère sur les tranches et découper le fromage grossièrement en gros dés. Cuire 20/25 mn dans un four préchauffé Th 7.",
     "type_repas": "entree",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "semaine",
+    "public": "kids"
   },
   {
     "id": "p20",
@@ -277,7 +315,9 @@
     "ingredients": "Sucre (80 g)|Beurre (100 g)|Sel (QS)|Lait (200 ml)|Œufs (2)|Pâtes (150 g)",
     "instructions": "Dans un récipient, mélangez la levure avec le lait et un peu de sucre. Laissez reposer pendant 5 minutes. Versez la farine, le sucre, la levure fraîche, le lait et le sel dans le bol de votre robot muni du crochet pétrisseur. Pétrissez le tout pendant 10 minutes. Incorporez les œufs, un à un, en continuant à pétrir. Ajoutez le beurre en morceaux et pétrissez encore pendant 5 minutes. Couvrez le bol de votre robot avec un torchon propre et laissez la pâte lever à température ambiante pendant 2 heures. Dégazez délicatement la pâte. Sur un plan de travail fariné, étalez la pâte. Étalez une fine couche de pâte de pistache sur la surface, puis formez un rouleau en enroulant la pâte. Coupez le rouleau en deux dans le sens de la longueur. Tressez ensuite les deux morceaux ensemble. Placez la tresse dans un moule à cake. Enfournez à 180 °C pour une durée de 30 à 35 minutes. Vérifiez la cuisson. Laissez refroidir légèrement avant de démouler.",
     "type_repas": "dessert",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "we",
+    "public": "tous"
   },
   {
     "id": "p21",
@@ -291,7 +331,9 @@
     "ingredients": "Sucre (80 g)|Beurre (100 g)|Sel (QS)|Lait (200 ml)|1 œuf|100 g de vergeoise brune|Beurre (40 g)|Cannelle (2 c. c.)",
     "instructions": "Dans un récipient, dissoudre la levure dans le lait tiède avec un peu de sucre. Laissez reposer pendant 5 minutes. Versez la farine, le sucre semoule, la levure fraîche dissoute dans le lait et le sel dans le bol de votre robot équipé du crochet. Mélangez pendant 10 minutes jusqu'à ce que la pâte devienne lisse. Incorporez les œufs un par un, tout en continuant de pétrir. Ajoutez ensuite le beurre coupé en morceaux et pétrissez encore 5 minutes à vitesse moyenne. Couvrez le bol d’un linge propre et laissez la pâte lever pendant 2 heures à température ambiante. Dégazez la pâte pour éliminer l’air. Faites fondre le beurre demi-sel au micro-ondes. Dans un récipient, mélangez la vergeoise brune, le beurre fondu, la cannelle en poudre et un œuf, jusqu’à obtenir une préparation lisse et homogène. Farinez légèrement votre plan de travail et étalez la pâte en un grand rectangle. Étalez ensuite uniformément la préparation à la cannelle sur toute la surface de la pâte avant de la rouler en boudin. Coupez ce boudin en deux dans le sens de la longueur. Entrelacez les deux morceaux et formez une couronne avec cette tresse. Placez la couronne dans un moule adapté. Enfournez à 180 °C pendant 35 minutes pour une cuisson dorée et bien cuite.",
     "type_repas": "dessert",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "we",
+    "public": "tous"
   },
   {
     "id": "p22",
@@ -305,7 +347,9 @@
     "ingredients": "Veau (QS)|Soupes (QS)|Harissa (1 c. c.)|Agneau (500 g)|Oignons (1)|Ail (2 gousses)|Abricots (150 g)|Amandes (50 g)|Cannelle (1 c. c.)|Eau (500 ml)|Menthe (QS)|Poivre (QS)",
     "instructions": "Pelez l’oignon et émincez-le. Pelez les gousses d’ail et ôtez-en les germes. Hachez l’ail finement. Lavez et séchez bien la menthe avant d’en récupérer les feuilles et de les ciseler finement. Coupez la viande en gros cubes selon les morceaux employés. Déposez celle-ci dans la cuve du Cookeo avec l’huile d’olive. Faites cuire en mode DORER pendant 5 minutes. Retourner régulièrement la viande afin de bien colorer toutes les faces. Ajoutez l’oignon et l’ail. Remuez et laissez cuire durant 3 minutes supplémentaires. Intégrez la farine et mélangez bien avec un ustensile en bois. Ajoutez ensuite le fond de veau, la cannelle et le miel. Salez et poivrez puis couvrez avec l’eau. Mélangez légèrement. Laissez cuire sous pression durant 25 minutes. Ouvrez et ajoutez les abricots secs et les amandes ainsi que la menthe fraîche. Laissez en mode Maintien au chaud pendant 10 minutes (ou davantage si vous souhaitez que la sauce épaississe davantage).",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "we",
+    "public": "adultes"
   },
   {
     "id": "p23",
@@ -319,7 +363,9 @@
     "ingredients": "Bananes (3)|Farine (200 g)|Sucre (100 g)|Œufs (2)|Beurre (80 g)|Levure (1 sachet)|Cannelle (1 c. c., optionnel)",
     "instructions": "Préchauffer le four à 180°C. Écraser les bananes et mélanger avec le sucre, l'oeuf et le beurre fondu. Ajouter la farine, la levure et la cannelle. Remplir des moules à muffins et cuire 20 minutes jusqu'à ce qu'ils soient gonflés et dorés.",
     "type_repas": "dessert",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "semaine",
+    "public": "kids"
   },
   {
     "id": "p24",
@@ -333,7 +379,9 @@
     "ingredients": "Farine (200 g)|Beurre (100 g)|Sucre (100 g)|Œufs (1)|Chocolats (150 g)|Levure (1/2 sachet)|Vanille (1 c. c.)|Sel (QS)",
     "instructions": "Préchauffer le four à 180°C. Mélanger le beurre ramolli avec le sucre, ajouter les oeufs et la vanille. Incorporer la farine, la levure et les pépites de chocolat. Former des boules sur une plaque et cuire 10-12 minutes jusqu'à ce qu'ils soient dorés. Laisser refroidir avant de déguster.",
     "type_repas": "dessert",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "semaine",
+    "public": "kids"
   },
   {
     "id": "p25",
@@ -347,7 +395,9 @@
     "ingredients": "Yaourts (1 pot)|Farine (3 pots)|Sucre (2 pots)|Œufs (3)|Huile (1/2 pot)|Levure (1 sachet)|Vanille (1 c. c.)",
     "instructions": "Préchauffer le four à 180°C. Utiliser le pot de yaourt comme mesure : mélanger 1 pot de yaourt, 2 pots de sucre, 3 pots de farine, 1/2 pot d'huile, 3 oeufs et la levure. Ajouter la vanille. Verser dans un moule et cuire 30-35 minutes. Vérifier la cuisson avec un couteau.",
     "type_repas": "dessert",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "tous",
+    "public": "kids"
   },
   {
     "id": "p26",
@@ -361,7 +411,9 @@
     "ingredients": "Farine (250 g)|Lait (500 ml)|Œufs (3)|Sucre (2 c. s.)|Beurre (30 g)|Sel (QS)",
     "instructions": "Mélanger la farine, le sucre et le sel. Ajouter les oeufs et incorporer progressivement le lait pour éviter les grumeaux. Laisser reposer 30 minutes si possible. Cuire dans une poêle chaude avec un peu de beurre, 1-2 minutes par côté. Servir avec du sucre, de la confiture ou du chocolat.",
     "type_repas": "dessert",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "tous",
+    "public": "kids"
   },
   {
     "id": "p27",
@@ -375,7 +427,9 @@
     "ingredients": "Saumon (500 g)|Asperges (500 g)|Citron (1)|Huile olive (2 c. s.)|Ail (2 gousses)|Herbes de Provence (1 c. c.)|Sel, poivre (QS)",
     "instructions": "Assaisonner le saumon avec huile, ail et herbes. Griller 5-7 minutes de chaque côté. Cuire le riz. Arroser de jus de citron et servir.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "we",
+    "public": "adultes"
   },
   {
     "id": "p28",
@@ -389,7 +443,9 @@
     "ingredients": "Œufs (6)|Champignons (250 g)|Épinards frais (300 g)|Oignons (1)|Fromages (100 g, optionnel)|Huile olive (2 c. s.)|Sel, poivre (QS)",
     "instructions": "Faire sauter les champignons, épinards et oignon. Battre les œufs et verser sur les légumes. Cuire 3-5 minutes, plier et servir chaud.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "semaine",
+    "public": "kids"
   },
   {
     "id": "p29",
@@ -403,7 +459,9 @@
     "ingredients": "Filets de dinde (500 g)|Pommes de terre (750 g)|Herbes (thym, romarin) (QS)|Ail (2 gousses)|Huile olive (2 c. s.)|Citron (1)|Sel, poivre (QS)",
     "instructions": "Mariner la dinde avec herbes, ail et huile. Rôtir les patates douces au four 20 minutes. Griller la dinde 10-15 minutes. Servir avec un filet de citron.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "tous",
+    "public": "tous"
   },
   {
     "id": "p30",
@@ -417,7 +475,9 @@
     "ingredients": "Cabillaud (500 g)|Carottes (300 g)|Courgettes (400 g)|Citron (1)|Herbes fraîches (QS)|Huile olive (2 c. s.)|Sel, poivre (QS)",
     "instructions": "Placer le poisson et légumes tranchés sur du papier aluminium. Arroser d’huile et citron, assaisonner. Fermer la papillote et cuire au four 15 minutes à 180°C.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "tous",
+    "public": "tous"
   },
   {
     "id": "p31",
@@ -431,7 +491,9 @@
     "ingredients": "Pois chiches (250 g)|Oignons (1)|Ail (2 gousses)|Persil (1 bouquet)|Cumin (1 c. c.)|Pois chiches (QS)|Huile pour friture (500 ml)|Salade (200 g)",
     "instructions": "Mixer les pois chiches avec oignon, ail et épices. Former des boules et frire 5 minutes. Servir avec une salade fraîche assaisonnée.",
     "type_repas": "entree",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "semaine",
+    "public": "tous"
   },
   {
     "id": "p32",
@@ -445,7 +507,9 @@
     "ingredients": "Poulet (500 g)|Poivrons (400 g)|Tomates (400 g)|Oignons (2)|Ail (2 gousses)|Piment d’Espelette (1 c. c.)|Huile olive (2 c. s.)|Sel, poivre (QS)",
     "instructions": "Faire dorer le poulet. Ajouter oignon, ail et poivrons. Incorporer tomates et piment, mijoter 30 minutes. Servir avec du riz ou du pain.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "tous",
+    "public": "tous"
   },
   {
     "id": "p33",
@@ -459,7 +523,9 @@
     "ingredients": "Fruits rouges congelés (400 g)|Bananes (2)|Lait (400 ml)|Graines de chia (2 c. s.)|Noix (60 g)|Miel (2 c. s., optionnel)",
     "instructions": "Mixer les fruits avec le lait végétal. Verser dans un bol, garnir de graines, noix et tranches de banane. Servir immédiatement.",
     "type_repas": "entree",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "tous",
+    "public": "tous"
   },
   {
     "id": "p34",
@@ -473,7 +539,9 @@
     "ingredients": "pâte feuilletée (230 g)|Oignons (1)|Huile olive (2 c. s.)|Sel (QS)|Poivre (QS)|1 bûche de chèvre|Herbes de Provence (1 c. c.)|Carottes (300 g)|Courgettes (300 g)|Poivrons (200 g)",
     "instructions": "Préchauffez votre four à 180°C (thermostat 6). Épluchez et coupez les carottes et les courgettes en rondelles puis émincez les poivrons et l'oignon. Faites précuire les carottes à la vapeur (il faut qu'elles soient cuites mais encore croquantes). Ensuite, faites mijoter tous les légumes dans de l'huile d'olive à feu doux pendant 10 min. Assaisonnez avec du sel, du poivre et des herbes de Provence. Disposez les légumes au fond d'un plat anti-adhésif en tassant bien (si vous avez du courage, vous pouvez 'organiser' la disposition des légumes pour que ça soit joli à la présentation). Ajoutez par-dessus quelques tranches de chèvre en les espaçant bien. Sur chaque tranche de chèvre, ajoutez une demie cuillère à café de miel (pas trop liquide). Déposez la pâte par-dessus en la rentrant bien sur les côtés pour qu'elle couvre la préparation. Enfournez environ 30 min, jusqu'à cuisson de la pâte. Démoulez délicatement dans un grand plat et servez avec une salade de mâche (ou autre) au balsamique.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "tous",
+    "public": "tous"
   },
   {
     "id": "p35",
@@ -487,7 +555,9 @@
     "ingredients": "Huile olive (2 c. s.)|Huile olive (1 c. s.)|Sel (QS)|Poivre (QS)|Fromage râpé (120 g)|Bœuf (500 g)|Paprika (1 c. c.)|Herbes de Provence (1 c. c.)",
     "instructions": "Découpez les aubergines en rondelles, puis faites-les cuire dans le Airfryer pendant 10 minutes. Programmez votre appareil à 180°C. Pendant ce temps, faites chauffer un filet d'huile d'olive dans une poêle. Faites-y revenir l'oignon émincé et l'ail haché jusqu'à ce qu'ils soient tendres. Incorporez la viande hachée et laissez-la dorer en remuant régulièrement. Ajoutez ensuite les tomates concassées, les herbes de Provence, le paprika, le sel et le poivre. Mélangez bien et laissez mijoter pendant 10 minutes à feu doux. Dans un plat adapté , disposez une première couche d'aubergines, puis recouvrez de préparation à la viande. Répétez l'opération jusqu'à épuisement des ingrédients. Parsemez de fromage râpé. Faites cuire dans le Airfryer à 180°C pendant 20 minutes, jusqu'à ce que le fromage soit gratiné et doré. Servez chaud.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "tous",
+    "public": "tous"
   },
   {
     "id": "p36",
@@ -501,7 +571,9 @@
     "ingredients": "Coriandre (QS)|Poulet (500 g)|Oignons (1)|Ail (2 gousses)|Curry (1 c. s.)|Lait (400 ml)|Huile de coco (2 c. s.)|Sauce soja (2 c. s.)|Poivre (QS)",
     "instructions": "Lavez, séchez et ciselez la coriandre. Pelez l’oignon et émincez-le. Pelez les gousses d’ail, ôtez les germes et écrasez à l’aide d’un presse-ail. Coupez les filets de poulet en gros morceaux et assaisonnez-les avec la sauce soja, un peu de poivre et l’huile de coco. Disposez le poulet avec l’ail et l’oignon dans un plat adapté . Mélangez le tout et faites précuire 5 min à 180 °C. Sortez le plat et ajoutez la pâte de curry vert. Arrosez de 200 ml de lait de coco. Mélangez bien. Faites cuire  à 180°C pendant 15 minutes. Ajoutez l’autre moitié du lait de coco et mélangez à nouveau. Relancez le Airfryer à 180 °C durant 15 minutes. Vérifiez la cuisson du poulet (si nécessaire, prolongez de 5 min). Parsemez de coriandre ciselée et servez bien chaud avec du riz.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "tous",
+    "public": "tous"
   },
   {
     "id": "p37",
@@ -515,7 +587,9 @@
     "ingredients": "Poivre (QS)|Sel (QS)|Beurre (40 g)|Oignons (2)|Bouillon cube (1)|Huile olive (3 c. s.)|Tomates (400 g)|Poulet (500 g)|Paprika (1 c. c.)|Eau (400 ml)|Riz (300 g)|Riz (QS)|Vin blanc (150 ml)|Crème liquide (200 ml)",
     "instructions": "Lavez, séchez et ciselez le persil. Réservez. Rincez le riz. Lavez et séchez les poivrons. Ôtez-en le pédoncule et les graines et coupez-les en petits dés. Pelez l’oignon et enlevez le germe. Émincez finement. Pelez l’oignon et émincez-le également. Mixez les tomates confites avec un peu d’huile d’olive dans un blender pour obtenir une pâte bien lisse. Mélangez celle-ci au riz. Ajoutez le paprika et 40 cl d’eau. Mélangez bien. Déposez dans un plat passant au four et laissez cuire 20 min à 200 °C. Salez légèrement le poulet. Faites chauffer une sauteuse et versez-y un peu d’huile avant d’y déposer les morceaux de poulet, côté peau en premier. Laissez bien colorer puis tourner pour marquer toutes les faces. Sortir du plat et réserver. Faites fondre l’oignon dans le même plat. Ajoutez également l’ail. Quand ceux-ci sont presque cuits, ajoutez les poivrons en dés, salez légèrement et ajoutez le piment d’Espelette. Mélangez sur feu vif. Déglacez au vin blanc et laissez mijoter sur feu doux durant 6 min. Mélangez bien et ajoutez les tomates concassées. Réintégrez la viande (et le jus rendu) et couvrez. Laissez cuire à feu doux 15 min. Pelez le chorizo. Coupez-le en petits dés. Faites chauffer la crème dans une casserole et ajoutez-y le bouillon cube. Portez à frémissements et ajoutez 50 g de chorizo. Faites chauffer pour le chorizo infuse bien puis, après environ 10 min. Ajoutez le beurre en cubes (il doit être bien froid) et mélangez bien. Une fois la sauce obtenue, filtrez-la pour qu’elle ait un bel aspect lisse et réservez. Récupérez le chorizo et ajoutez-le dans la sauteuse principale avec le poulet. Mélangez bien. Ajoutez le persil haché dans le riz à la tomate. Mélangez. Servez le riz et le poulet en sauce dans deux plats distincts.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "tous",
+    "public": "tous"
   },
   {
     "id": "p38",
@@ -529,7 +603,9 @@
     "ingredients": "Citron (2)|Épices (1 c. c.)|Huile olive (3 c. s.)|Sel (QS)|Poivre (QS)|Agneau (500 g)|Citron (QS)|Ail (2 gousses)",
     "instructions": "Rincez et épongez les herbes avec un papier absorbant. Pelez et hachez l'ail. Découpez les citrons en petits morceaux et placez-les dans un bol. Ajoutez les herbes finement ciselées, l'ail haché, les épices, l'huile d’olive, le sel et le poivre. Mélangez le tout jusqu’à obtenir une préparation homogène. Disposez les côtelettes d’agneau dans un grand plat allant au four. Nappez-les de la moitié de la marinade, retournez-les pour bien les enrober, puis versez le reste de la marinade sur le dessus. Couvrez avec du film plastique et laissez mariner pendant au moins 2 heures. Préchauffez votre four à 200°C en chaleur tournante. Enfournez les côtelettes d'agneau et laissez-les cuire pendant 15 à 20 minutes, en fonction de leur épaisseur et de la cuisson désirée. Retournez-les à mi-cuisson pour qu’elles dorent uniformément. Sortez les côtelettes du four et servez-les bien dorées.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "we",
+    "public": "adultes"
   },
   {
     "id": "p39",
@@ -543,7 +619,9 @@
     "ingredients": "Huile olive (1 c. s.)|Thym (QS)|Sel (QS)|Poivre (QS)|Camembert (250 g)|Vin blanc sec (2 c. s.)",
     "instructions": "Retirez le couvercle de la boîte du camembert et creusez légèrement le centre de chaque camembert pour y faire un petit puits. Versez un filet d'huile d'olive dans chaque creux. Ajoutez une cuillère de vin blanc et parsemez de thym. Nappez de miel et assaisonnez avec du sel et du poivre selon votre goût. Replacez le camembert dans sa boîte sans le couvercle et enfournez pendant 20 minutes, jusqu'à ce que le fromage soit bien coulant. Servez aussitôt.",
     "type_repas": "entree",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "semaine",
+    "public": "tous"
   },
   {
     "id": "p40",
@@ -557,7 +635,9 @@
     "ingredients": "pâte brisée (230 g)|Sucre (100 g)|Beurre (100 g)|Poires (600 g)|Amandes (120 g)|Œufs (2)|Vanille (1 c. c.)",
     "instructions": "Abaissez la pâte brisée dans un moule à tarte compatible , puis percez le fond avec une fourchette. Dans un bol, mélangez la poudre d’amandes, les œufs, le beurre fondu, le sucre et le sucre vanillé. Versez le tout sur le fond de tarte. Pelez les poires, coupez-les en tranches et répartissez-les sur le mélange. Placez le plat à tarte dans le panier du Airfryer et lancez la cuisson à 180°C pendant 25 minutes.",
     "type_repas": "dessert",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "tous",
+    "public": "tous"
   },
   {
     "id": "p41",
@@ -571,7 +651,9 @@
     "ingredients": "Oignons (1)|Huile olive (2 c. s.)|Sel (QS)|Poivre (QS)|Coriandre (QS)|Poulet (500 g)|Lait (400 ml)|Ail (2 gousses)|Curry (1 c. s.)",
     "instructions": "Coupez les filets de poulet en morceaux. Dans un saladier, mélangez le lait de coco, la pâte de curry, l’ail et l’huile d’olive. Salez et poivrez à votre convenance. Ajoutez le poulet, mélangez bien et laissez mariner pendant 30 minutes au frigo. Placez le poulet au curry dans le panier du Airfryer et faites cuire pendant 15 minutes à 180°C.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "tous",
+    "public": "tous"
   },
   {
     "id": "p42",
@@ -585,7 +667,9 @@
     "ingredients": "Oignons (1)|Huile olive (2 c. s.)|Sel (QS)|Poulet (500 g)|Butternut (400 g)|Pommes de terre (300 g)|Herbes de Provence (1 c. c.)|Poivre (QS)",
     "instructions": "Pelez la courge et retirez-en les graines (gardez-les pour une autre recette). Coupez-la en petits dés. Lavez et pelez les carottes ainsi que les patates douces avant de les tailler en dés également. Pelez l’oignon et émincez-le finement. Déposez l’ensemble des légumes dans un plat à gratin adapté à votre Airfryer. Arrosez d’huile d’olive et saupoudrez les herbes de Provence. Assaisonnez. Mélangez le tout en réservant 4 emplacements pour déposer les cuisses de poulet. Déposez les cuisses et arrosez-les d’un peu d’huile. Lancez la cuisson à 200°C pendant 30 minutes. Ouvrez et mélangez les légumes. Retournez les cuisses de poulet et terminez la cuisson pendant 5 minutes à la même température. Servez bien chaud.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "tous",
+    "public": "tous"
   },
   {
     "id": "p43",
@@ -599,7 +683,9 @@
     "ingredients": "Fécule de maïs (30 g)|Levure (1 c. c.)|Sucre (150 g)|Beurre (100 g)|Pâtes (230 g)|Citron (4)",
     "instructions": "Foncez un moule à tarte préalablement beurré avec la pâte sablée. Faites cuire à blanc (en utilisant des poids de cuisson) à 180°C durant 20 minutes. Réservez. Lavez les citrons et séchez-les bien. Prélevez les zestes très fins sur deux d’entre eux et pressez les 4 pour en récupérer tout le jus. Versez dans une casserole avec les zestes, le sucre semoule et la Maïzena. Remuez. Faites chauffer doucement. Battez 3 œufs dans un saladier et versez-les progressivement dans la casserole en remuant constamment. Battez sur feu vif pour faire épaissir le mélange. Veillez à bien racler les bords afin d’éviter que la crème accroche et brûle. Versez cet appareil dans le fond de tarte. Pendant que la préparation refroidit, préparez une meringue dense. Montez les blancs de 2 œufs frais en neige. Ajoutez la levure chimique et le sucre glace. Continuez à battre pour une meringue très solide. Déposez cette meringue sur votre tarte. Mettez à cuire à 120°C dans le Airfryer pendant 10 minutes. La meringue doit légèrement colorer. Laissez refroidir avant de servir.",
     "type_repas": "dessert",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "tous",
+    "public": "tous"
   },
   {
     "id": "p44",
@@ -613,7 +699,9 @@
     "ingredients": "Huile olive (2 c. s.)|Beurre (40 g)|Sel (QS)|Pommes de terre (à purée) (800 g)|Bœuf (500 g)|Oignons (1)|Ail (2 gousses)|Emmental (100 g)|Chapelure (30 g)|Muscade (QS)|Poivre (QS)",
     "instructions": "Pelez les pommes de terre, rincez-les et faites les cuire dans une casserole d'eau bouillante salée durant 25 minutes environ. Égouttez et passez le tout au presse-purée pour obtenir la texture souhaitée. Ajoutez le beurre et la muscade. Salez et poivrez. Mélangez. Pelez l’oignon et émincez-le. Faite de même avec la carotte et l’ail. Déposez l’oignon et l’ail dans un petit plat passant au Airfyer. Arrosez d’un peu d’huile, mélangez et faites cuire 3 minutes à 180°C. Ajoutez-y la carotte et la viande émincée et mélangez. Faites cuite à 180°C durant 3 minutes supplémentaires. Salez légèrement et poivrez. Beurrez légèrement le fond d’un plat à gratin adapté à votre Airfryer. Déposez la préparation de viande au fond en une couche uniforme. Couvrez avec une belle couche de purée de pommes de terre. Saupoudrez d’emmental râpé puis de chapelure. Poivrez. Fermez le panier du Airfryer et lancez la cuisson pour 12 minutes à 180°C. Si nécessaire, prolongez la cuisson de quelques minutes pour que le dessus soit parfaitement gratiné et croustillant. Servez bien chaud avec une salade verte.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "tous",
+    "public": "kids"
   },
   {
     "id": "p45",
@@ -627,7 +715,9 @@
     "ingredients": "Beurre (100 g)|Sucre (60 g)|Sucre (80 g)|Pâtes (230 g)|Pommes (500 g)|Œufs (2)|Eau (2 c. s.)|Crème liquide (150 ml)|Amandes (60 g)",
     "instructions": "Préchauffez votre four à 180°C. Placez la farine et le beurre en morceaux dans le bol du Thermomix, puis mixez pendant 20 secondes en vitesse 4. Versez le sucre glace et mixez 5 secondes en vitesse 4. Incorporez ensuite l'œuf et versez l'eau puis mélangez 10 secondes en vitesse 5. Déposez la pâte sur un plan de travail légèrement saupoudré de farine, puis abaissez-la à l’aide d’un rouleau à pâtisserie. Transférez-la ensuite dans un moule à tarte tapissé de papier sulfurisé. Épluchez et découpez les pommes en quartiers. Mettez-les dans le moule à tarte. Placez les œufs et le sucre dans le bol de votre Thermomix, puis mélangez pendant 1 minute en vitesse 4. Ajoutez la crème liquide ainsi que la poudre d’amande et mixez en vitesse 5 pendant 1 minute supplémentaire. Ajoutez la préparation sur le dessus et faites cuire le tout pendant 35 minutes.",
     "type_repas": "dessert",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "tous",
+    "public": "tous"
   },
   {
     "id": "p46",
@@ -641,7 +731,9 @@
     "ingredients": "Haricots rouges (1 boîte de 400 g)|Huile olive (2 c. s.)|Sel (QS)|Poivre (QS)|Tortillas (8 petites)|Oignons (1)|Maïs (150 g)|Paprika (1 c. c.)|Citron (2 c. s.)|Yaourts (1)|Citron (1 c. s.)|Ail (1 gousse)",
     "instructions": "Lavez et coupez les poivrons en fines lanières. Taillez la courgette en bâtonnets. Émincez l’oignon rouge. Dans un grand saladier, mélangez les légumes avec l’huile d’olive, le paprika, le cumin, du sel et du poivre. Ajoutez le jus de citron vert et mélangez bien. Déposez les légumes assaisonnés dans le panier du Airfryer en une couche uniforme. Faites cuire pendant 15 minutes à 180°C, en remuant à mi-cuisson, jusqu’à ce que les légumes soient tendres et légèrement grillés. Égouttez et rincez les haricots rouges et le maïs. Ajoutez-les aux légumes cuits dans un bol et mélangez. Mélangez le yaourt nature, le jus de citron, l’ail pressé, du sel et du poivre. Réservez. Faites chauffer légèrement les tortillas à nouveau dans le panier du Airfryer pendant environ 5 minutes à 180°C. Garnissez chaque tortilla avec les légumes cuits, les haricots rouges et le maïs. Ajoutez une cuillère de sauce au yaourt et parsemez de coriandre fraîche.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "semaine",
+    "public": "tous"
   },
   {
     "id": "p47",
@@ -655,7 +747,9 @@
     "ingredients": "Citron (2)|Citron (QS)|Oignons (2)|Oignons (QS)|Huile olive (3 c. s.)|Huile olive (QS)|Coriandre (QS)|Coriandre (QS)|Sel (QS)|Poivre (QS)|Poulet (500 g)|Poulet (QS)|Ail (2 gousses)|Ail (QS)|Gingembre (2 cm)|Gingembre (QS)|Cannelle (1 c. c.)|Cannelle (QS)|Bouillon cube (1)|Bouillon cube (QS)|Eau (400 ml)",
     "instructions": "Lavez et coupez les citrons confits en quartiers. Coupez les pruneaux en deux si vous préférez des morceaux plus petits. Hachez l’ail, émincez les oignons et râpez le gingembre. Dans le panier de votre Airfryer, ajoutez les cuisses de poulet et les oignons émincés. Mélangez l’ail, le gingembre, le curcuma, le cumin et la cannelle avec l'huile d'olive pour former une marinade. Enrobez la volaille avec. Placez le mélange avec les morceaux de poulet. Ajoutez les pruneaux et les citrons confits. Salez et poivrez. Faites cuire l'ensemble des ingrédients pendant 20 minutes à 180°C dans votre Airfryer, jusqu’à ce que le poulet soit bien cuit et tendre. Parsemez de coriandre fraîche hachée juste avant de servir.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "we",
+    "public": "adultes"
   },
   {
     "id": "p48",
@@ -669,7 +763,9 @@
     "ingredients": "Crème fraîche (100 g)|Beurre (60 g)|Sel (QS)|Œufs (6)|Poivre (QS)",
     "instructions": "Cassez les œufs dans le bol du Thermomix. Ajoutez-y 20 g de beurre ramolli ainsi qu’une càs de crème fraîche. Lancez le Thermomix 8 minutes à 80 °C et en vitesse 5. Assaisonnez avec le sel et le poivre. Ajoutez le reste de beurre et de crème épaisse avant de relancer l’appareil pendant 30 secondes à 80 °C, et en vitesse 5. Servez aussitôt avec une belle tranche de pain grillé",
     "type_repas": "entree",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "semaine",
+    "public": "kids"
   },
   {
     "id": "p49",
@@ -683,7 +779,9 @@
     "ingredients": "Bouillon cube (1)|Mirin (2 c. s.)|Gingembre (2 cm)|Huile (2 c. s.)|Sucre (1 c. c.)|Sel (QS)|Poivre (QS)|Nouilles udon (250 g)|Shiitaké (150 g)|Bœuf (250 g)|Pak choi (200 g)|Oignons (1)|Ail (2 gousses)|Sauce soja (3 c. s.)",
     "instructions": "Faites cuire les nouilles udon en réduisant leur temps de cuisson de 2 à 3 minutes par rapport aux indications du paquet. Rafraîchissez-les immédiatement sous un filet d’eau froide pour arrêter la cuisson et mettez-les de côté. Rincez soigneusement les shiitakés et découpez-les en quartiers ou en morceaux plus petits selon leur taille. Faites bouillir le bouillon de bœuf dans une marmite d'eau en l'émiettant. Incorporez le mirin avec une cuillère de sauce soja. Gardez la préparation au chaud. Coupez le bœuf en lamelles fines. Nettoyez et émincez les cébettes. Épluchez et taillez finement la gousse d'ail et le gingembre frais. Enlevez les pépins du poivron et coupez-le en brunoise. Lavez et découpez finement le chou pack choï. Faites chauffer deux cuillères d'huile et le sucre. Mettez aussi les morceaux de pack choï et les champignons pour les faire revenir à feu moyen-vif pendant 5 minutes en mélangeant. Intégrez les oignons, le poivron, une cuillère de sauce soja, l'ail et le gingembre. Puis assaisonnez avec du sel et du poivre. Remuez quelques minutes. Réchauffez les nouilles udon dans le bouillon pendant 2 à 3 minutes environ. Déposez ensuite le tout dans les bols. Ajoutez la viande. Le bouillon la cuira immédiatement. Saupoudrez de morceaux de cébettes. Bon appétit !",
     "type_repas": "entree",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "tous",
+    "public": "tous"
   },
   {
     "id": "p50",
@@ -697,7 +795,9 @@
     "ingredients": "Huile olive (3 c. s.)|Semoule (300 g)|Sel (QS)|Poivre (QS)|Poulet (500 g)|Oignons (2)|Sauce soja (2 c. s.)|Paprika (1 c. c.)",
     "instructions": "Coupez les filets de poulet en morceaux réguliers. Découpez les poivrons et l’oignon en morceaux de taille similaire. Dans un bol, mélangez l’huile d’olive, la sauce soja, le miel, le paprika, le curry, l’ail en poudre, le sel et le poivre. Ajoutez les morceaux de poulet dans la marinade. Mélangez bien pour enrober chaque morceau.Laissez mariner pendant au moins 30 minutes. Enfilez les morceaux de poulet, de poivron et d’oignon sur les brochettes, en alternant les ingrédients. Déposez les brochettes dans le panier du Airfryer et faites cuire pendant 12 minutes à 180°C, en retournant les brochettes à mi-cuisson pour qu’elles dorent de tous les côtés.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "tous",
+    "public": "tous"
   },
   {
     "id": "p51",
@@ -711,7 +811,9 @@
     "ingredients": "Huile olive (2 c. s.)|pain de mie (8 tranches)|Bûche de chèvre (180 g)|Pignons (30 g)|Poivre (QS)",
     "instructions": "Arrosez les tranches de pain avec un filet d’huile d’olive. Coupez la buche de chèvre en 8 tranches assez épaisses. Déposez deux tranches de fromage par tranche de pain. Saupoudrez un peu de romarin. Poivrez généreusement et parsemez de quelques pignons de pain. Déposez les tranches (en plusieurs fois si besoin), dans le panier du Airfryer. Faites cuire à 200 ° C pendant 4 minutes. Sortez les toasts et arrosez d’un filet de miel. Dégustez bien chaud avec une salade de saison.",
     "type_repas": "entree",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "semaine",
+    "public": "tous"
   },
   {
     "id": "p52",
@@ -725,7 +827,9 @@
     "ingredients": "Thym (QS)|Thym (QS)|Noix (100 g)|Jambon Herta (4 tranches)|Brie (150 g)|Saucisson sec (150 g)|Grenade (1)|Pommes (2)|Riz (QS)|Chèvre frais (150 g)|Mortadelle (100 g)|Jambon Herta (4 tranches)|Amandes (60 g)|Pistaches (60 g)|Cranberries (50 g)|Crottin de chèvre (1)|Cracker (150 g)",
     "instructions": "Pour commencer le plateau apéro, faire des roses en chorizo. Pour cette étape, prendre un verre. Déposer les tranches de chorizo sur les bords du verre, enrouler la dernière tranche et la placer au milieu. Retourner le verre et les roses en chorizo sont prêtes. Disposer le chorizo sur une planche en bois ronde. Disposer, tout le long de la planche, du fromage et de la charcuterie. La couronne apéro de Noël est prête.",
     "type_repas": "entree",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "we",
+    "public": "tous"
   },
   {
     "id": "p53",
@@ -739,7 +843,9 @@
     "ingredients": "pâte brisée (230 g)|Chocolats (200 g)|Beurre (80 g)|Sucre (60 g)|Poires (600 g, bio si possible)|Crème liquide (200 ml)|Œufs (2)|Sucre (60 g)",
     "instructions": "Cassez le chocolat en morceaux et faites le fondre au bain-marie ou au four à micro-ondes avec le beurre. Mélangez bien. Foncer un moule à tarte (chemisé avec un peu beurre) adapté à votre Airfryer avec la pâte brisée. Percez le fond à l’aide d’une fourchette. Versez le mélange à base de chocolat dans le fond de tarte. Pelez les poires. Enlevez le cœur avec les pépins. Coupez en tranches fines (mais pas trop). Disposez-les élégamment sur le chocolat pour en couvrir toute la surface. Dans un bol, battez-les œufs avec la crème liquide et le sucre en poudre. Versez ce mélange sur la tarte en répartissant bien. Déposez la tarte dans le Airfryer. Faites cuire 20 minutes à 180 °C. Ouvrez et saupoudrez de cassonade et faites cuire à la même température durant 5 minutes supplémentaires. Laissez refroidir avant de déguster.",
     "type_repas": "dessert",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "tous",
+    "public": "kids"
   },
   {
     "id": "p54",
@@ -753,7 +859,9 @@
     "ingredients": "Pâtes (2 pâtes feuilletées)|Sucre (100 g)|Beurre (100 g)|Amandes (150 g)|Œufs (2)|1 fève",
     "instructions": "Dans un bol, incorporez la poudre d’amandes, le sucre, les œufs et le beurre mou, puis mélangez jusqu’à obtenir une texture onctueuse. Disposez une première pâte feuilletée dans un moule à tarte et piquez-la avec une fourchette. Répartissez la crème frangipane sur la surface tout en préservant un bord libre. Glissez la fève dans la garniture. Placez la seconde pâte feuilletée par-dessus et pressez les bords avec les doigts pour bien les sceller. Faites cuire la galette à 180°C dans le Airfryer pendant environ 20 minutes.",
     "type_repas": "dessert",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "semaine",
+    "public": "tous"
   },
   {
     "id": "p55",
@@ -767,7 +875,9 @@
     "ingredients": "Saumon (500 g)|500 g d’asperges vertes|Citron (1, zeste et jus)|Huile olive (2 c. s.)|Ail (2 gousses)|Échalotes (2, optionnel)|Ciboulette (QS)|Sel, poivre (QS)",
     "instructions": "Coupez l’extrémité dure des asperges, rincez-les et séchez-les. Chauffez 1 c. à s. d’huile dans une grande poêle. Faites revenir l’échalote 1 minute puis ajoutez les asperges avec une pincée de sel. Saisissez 3–4 minutes à feu vif, baissez le feu et poursuivez 4–5 minutes jusqu’à ce qu’elles soient tendres mais encore croquantes, ajoutez l’ail en fin de cuisson. Dans une seconde poêle antiadhésive, chauffez 1 c. à s. d’huile. Salez et poivrez les darnes de saumon. Saisissez-les 3–4 minutes côté peau, retournez et cuisez 2–3 minutes selon l’épaisseur (le cœur doit rester légèrement rosé). Hors du feu, arrosez avec le jus de citron et parsemez de zeste et d’herbes ciselées. Servez immédiatement les darnes sur un lit d’asperges, nappez du jus citronné de la poêle.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "we",
+    "public": "adultes"
   },
   {
     "id": "p56",
@@ -781,7 +891,9 @@
     "ingredients": "Thon (500 g)|avocat (2)|Sauce soja (3 c. s.)|Gingembre (2 cm)|Sésame (2 c. s.)|Huile olive (2 c. s.)|Citron (1)",
     "instructions": "Mariner le thon brièvement. Saisir 1-2 minutes de chaque côté. Trancher et servir avec avocat assaisonné de citron et sésame.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "we",
+    "public": "adultes"
   },
   {
     "id": "p57",
@@ -795,7 +907,9 @@
     "ingredients": "pâte brisée (230 g)|Pommes (700 g)|Cannelle (1 c. c.)|Beurre (40 g)|Citron (1)",
     "instructions": "Étaler la pâte, disposer les tranches de pommes assaisonnées de cannelle et citron. Cuire au four 30 minutes à 180°C.",
     "type_repas": "dessert",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "tous",
+    "public": "kids"
   },
   {
     "id": "p58",
@@ -809,7 +923,9 @@
     "ingredients": "Riz (300 g)|Champignons (300 g)|Oignons (1)|Bouillon cube (2)|Vin blanc (100 ml, optionnel)|Parmesan (80 g, optionnel)|Beurre (40 g)|Huile olive (2 c. s.)",
     "instructions": "Faire revenir l’oignon et les champignons. Ajouter le riz, déglacer au vin, puis incorporer le bouillon louche par louche en remuant jusqu’à absorption. Terminer avec du parmesan si désiré.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "we",
+    "public": "adultes"
   },
   {
     "id": "p59",
@@ -823,7 +939,9 @@
     "ingredients": "Poulet (1.2 kg)|Carottes (300 g)|Panais (250 g)|Pommes de terre (400 g)|Ail (4 gousses)|Herbes (thym, romarin) (QS)|Huile olive (3 c. s.)|Sel, poivre (QS)",
     "instructions": "Assaisonner le poulet et les légumes. Rôtir au four à 180°C pendant 45-60 minutes jusqu’à ce que le poulet soit doré et les légumes tendres.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "we",
+    "public": "kids"
   },
   {
     "id": "p60",
@@ -837,7 +955,9 @@
     "ingredients": "Pois chiches (400 g)|Tahini (3 c. s.)|Ail (1 gousse)|Citron (1)|Cumin (1 c. c.)|Huile olive (3 c. s.)|Crudités (carottes, céleri, concombre) (400 g)",
     "instructions": "Mixer les pois chiches avec tahini, ail, jus de citron et cumin. Ajouter de l’huile pour la texture. Servir avec des crudités.",
     "type_repas": "entree",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "semaine",
+    "public": "tous"
   },
   {
     "id": "p61",
@@ -851,7 +971,9 @@
     "ingredients": "Porc (filet mignon, 600 g)|Crème fraîche (200 g)|Moutarde (2 c. s.)|Échalotes (2)|Vin blanc (150 ml)|Beurre (30 g)|Sel, poivre (QS)",
     "instructions": "Saisir le porc dans du beurre avec l'échalote émincée. Déglacer au vin blanc, ajouter la moutarde et la crème. Mijoter 10 minutes et servir.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "tous",
+    "public": "tous"
   },
   {
     "id": "p62",
@@ -865,7 +987,9 @@
     "ingredients": "pâte brisée (230 g)|Pommes (700 g)|Cannelle (1 c. c.)|Beurre (40 g)|Citron (1)",
     "instructions": "Étaler la pâte, disposer les tranches de pommes assaisonnées de cannelle et citron. Cuire au four 30 minutes à 180°C.",
     "type_repas": "dessert",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "tous",
+    "public": "kids"
   },
   {
     "id": "p63",
@@ -879,7 +1003,9 @@
     "ingredients": "Lentilles cuites (400 g)|Betteraves cuites (300 g)|Oignons (1)|Huile olive (3 c. s.)|Vinaigre (1 c. s.)|Moutarde (1 c. c.)|Persil (QS)|Noix (40 g, optionnel)",
     "instructions": "Mélanger tous les ingrédients. Arroser de vinaigrette et servir frais.",
     "type_repas": "entree",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "semaine",
+    "public": "tous"
   },
   {
     "id": "p64",
@@ -893,7 +1019,9 @@
     "ingredients": "Poulet (500 g)|Citron (1)|Thym (QS)|Ail (2 gousses)|Huile olive (2 c. s.)|Bouillon cube (1)|Sel, poivre (QS)",
     "instructions": "Saisir le poulet, ajouter ail et thym. Déglacer au bouillon et jus de citron, mijoter 10 minutes. Servir avec des légumes vapeur.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "semaine",
+    "public": "tous"
   },
   {
     "id": "p65",
@@ -907,7 +1035,9 @@
     "ingredients": "Flocons d’avoine (200 g)|Lait (600 ml)|Fruits secs (raisins, abricots) (80 g)|Cannelle (1 c. c.)|Noix (40 g)|Miel (2 c. s., optionnel)",
     "instructions": "Cuire les flocons dans le lait avec cannelle. Ajouter fruits secs et noix avant de servir.",
     "type_repas": "entree",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "semaine",
+    "public": "tous"
   },
   {
     "id": "p66",
@@ -921,7 +1051,9 @@
     "ingredients": "Crevettes (500 g)|Quinoa (200 g)|Citron (1)|Coriandre (QS)|Ail (2 gousses)|Huile olive (2 c. s.)|avocat (2)",
     "instructions": "Cuire le quinoa. Mariner et griller les crevettes 3 minutes. Mélanger avec avocat et coriandre, arroser de citron.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "we",
+    "public": "adultes"
   },
   {
     "id": "p67",
@@ -935,7 +1067,9 @@
     "ingredients": "Tomates (8 grosses)|Chair à saucisse (400 g)|Oignons (1)|Ail (2 gousses)|Persil (QS)|Riz (100 g)|Sel, poivre (QS)",
     "instructions": "Vider les tomates et conserver le chapeau. Mélanger la chair à saucisse, le riz, l’oignon, l’ail et le persil. Farcir les tomates et remettre les chapeaux. Cuire 45 minutes au four à 180°C.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "tous",
+    "public": "kids"
   },
   {
     "id": "p68",
@@ -949,7 +1083,9 @@
     "ingredients": "Spaghetti (400 g)|Lardons (200 g)|Œufs (4)|Parmesan (80 g)|Crème fraîche (100 g, facultatif)|Sel, poivre (QS)",
     "instructions": "Cuire les pâtes. Faire revenir les lardons. Battre les œufs avec le parmesan. Mélanger les pâtes chaudes avec les lardons et le mélange œuf-fromage. Poivrer et servir aussitôt.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "semaine",
+    "public": "kids"
   },
   {
     "id": "p69",
@@ -963,7 +1099,9 @@
     "ingredients": "Spaghetti (400 g)|Bœuf haché (500 g)|Oignons (1)|Ail (2 gousses)|Tomates (400 g)|Carottes (1)|Huile olive (2 c. s.)|Sel, poivre (QS)",
     "instructions": "Faire revenir oignon, ail et carotte hachée. Ajouter la viande, puis les tomates. Laisser mijoter 20 minutes. Servir sur les pâtes chaudes avec du parmesan.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "tous",
+    "public": "kids"
   },
   {
     "id": "p70",
@@ -977,7 +1115,9 @@
     "ingredients": "Poulet (500 g)|Yaourts (2 pots)|Épices (garam masala/tikka) (2 c. s.)|Ail (2 gousses)|Citron (1)|Sel (QS)|Huile (2 c. s.)",
     "instructions": "Faire mariner le poulet dans le yaourt, les épices et le citron pendant 1h. Cuire à la poêle ou au four jusqu’à ce qu’il soit doré. Servir avec du riz.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "tous",
+    "public": "tous"
   },
   {
     "id": "p71",
@@ -991,7 +1131,9 @@
     "ingredients": "Tagliatelles (350 g)|Noix de Saint-Jacques (500 g)|Crème fraîche (150 ml)|Échalotes (2)|Vin blanc (100 ml)|Beurre (30 g)|Sel, poivre (QS)",
     "instructions": "Faire revenir l’échalote au beurre, ajouter les Saint-Jacques et cuire 2 minutes par face. Déglacer au vin blanc, ajouter la crème, assaisonner et servir avec les pâtes.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "we",
+    "public": "adultes"
   },
   {
     "id": "p72",
@@ -1005,7 +1147,9 @@
     "ingredients": "Poulet (escalopes, 500 g)|Farine (60 g)|Œufs battus (2)|Chapelure (100 g)|Beurre (40 g)|Citron (1)|Sel, poivre (QS)",
     "instructions": "Tremper les escalopes dans la farine, puis l’œuf, puis la chapelure. Faire dorer à la poêle. Servir chaud avec citron et salade.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "tous",
+    "public": "tous"
   },
   {
     "id": "p73",
@@ -1019,7 +1163,9 @@
     "ingredients": "Nouilles chinoises (300 g)|Poulet (400 g)|Légumes (carottes, poivrons, oignons) (400 g)|Ail (2 gousses)|Sauce soja (3 c. s.)|Sésame (2 c. s.)|Gingembre (2 cm)",
     "instructions": "Cuire les nouilles. Faire revenir le poulet et les légumes dans un wok avec l’ail et le gingembre. Ajouter les nouilles et la sauce soja. Sauter quelques minutes et servir.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "semaine",
+    "public": "tous"
   },
   {
     "id": "p74",
@@ -1033,7 +1179,9 @@
     "ingredients": "Poulet (entier, 1.2 kg)|Pommes de terre (600 g)|Ail (4 gousses)|Thym (QS)|Huile olive (3 c. s.)|Sel, poivre (QS)",
     "instructions": "Préchauffer le four à 200°C. Disposer le poulet dans un plat, entouré de pommes de terre coupées. Arroser d’huile, assaisonner et cuire environ 1h15 en arrosant régulièrement.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "we",
+    "public": "kids"
   },
   {
     "id": "p75",
@@ -1047,7 +1195,9 @@
     "ingredients": "pain de mie (4 pains à burger)|Steaks hachés (4, soit 500 g)|Fromages (4 tranches)|Tomates (2)|Salade (QS)|Oignons (1)|Sauces (ketchup, mayonnaise) (QS)",
     "instructions": "Cuire les steaks. Assembler les burgers avec pain, fromage, salade, tomate, oignon et sauces. Réchauffer légèrement à la poêle ou au four avant de servir.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "semaine",
+    "public": "kids"
   },
   {
     "id": "p76",
@@ -1061,7 +1211,9 @@
     "ingredients": "Blé (8 tortillas)|Poulet (500 g)|Poivrons (400 g)|Oignons (1)|Épices (mélange fajitas) (2 c. s.)|Tomates (300 g)|Crème fraîche (100 g)",
     "instructions": "Faire revenir le poulet et les légumes avec les épices. Garnir les tortillas, ajouter la sauce et rouler les fajitas. Servir chaud.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "semaine",
+    "public": "tous"
   },
   {
     "id": "p77",
@@ -1075,7 +1227,9 @@
     "ingredients": "Pizzas (2 pâtes)|Tomates (200 g, sauce)|mozzarella (250 g)|Jambon Herta (4 tranches)|Origan (1 c. c.)|Huile olive (2 c. s.)",
     "instructions": "Étaler la pâte, garnir de sauce tomate et des ingrédients choisis. Ajouter la mozzarella, arroser d’huile et cuire 15-20 min à 220°C.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "tous",
+    "public": "kids"
   },
   {
     "id": "p78",
@@ -1089,7 +1243,9 @@
     "ingredients": "Poulet (500 g)|Carottes (300 g)|Pommes de terre (400 g)|Courgettes (300 g)|Oignons (1)|Épices (cumin, curcuma, gingembre) (1 c. c. chacune)|Huile olive (2 c. s.)|Bouillon cube (1)",
     "instructions": "Faire revenir le poulet avec les épices et les oignons. Ajouter les légumes et un peu de bouillon. Laisser mijoter à feu doux 45 minutes. Servir chaud.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "we",
+    "public": "adultes"
   },
   {
     "id": "p79",
@@ -1103,7 +1259,9 @@
     "ingredients": "Couscous (semoule, 400 g)|Poulet (500 g)|Carottes (300 g)|Navets (200 g)|Courgettes (300 g)|Pois chiches (200 g)|Ras el hanout (1 c. s.)|Bouillon cube (1)",
     "instructions": "Cuire la viande avec les épices et les légumes dans le bouillon. Faire gonfler la semoule à part. Servir la viande et les légumes sur la semoule.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "we",
+    "public": "tous"
   },
   {
     "id": "p80",
@@ -1117,7 +1275,9 @@
     "ingredients": "Fromages (raclette, 800 g)|Pommes de terre (1 kg)|Charcuterie variée (400 g)|Cornichons (1 petit bocal)|Oignons (grelots) (QS)",
     "instructions": "Cuire les pommes de terre. Disposer sur la table le fromage et la charcuterie. Faire fondre le fromage à l’appareil et servir sur les pommes de terre.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "we",
+    "public": "tous"
   },
   {
     "id": "p81",
@@ -1131,7 +1291,9 @@
     "ingredients": "Pommes de terre (800 g)|Reblochon (1, ~450 g)|Lardons (200 g)|Oignons (1)|Crème fraîche (100 g)|Poivre (QS)",
     "instructions": "Cuire les pommes de terre et les couper en tranches. Faire revenir lardons et oignons. Monter dans un plat avec crème et reblochon. Cuire 20-25 min à 200°C.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "tous",
+    "public": "tous"
   },
   {
     "id": "p82",
@@ -1145,7 +1307,9 @@
     "ingredients": "pâte brisée (230 g)|Lardons (150 g)|Œufs (3)|Crème fraîche (150 g)|Lait (150 ml)|Gruyère râpé (100 g)|Sel, poivre (QS)",
     "instructions": "Étaler la pâte dans un moule, disposer les lardons. Mélanger œufs, crème, lait et fromage, verser sur les lardons. Cuire 30 min à 180°C.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "tous",
+    "public": "kids"
   },
   {
     "id": "p83",
@@ -1159,7 +1323,9 @@
     "ingredients": "Œufs (8)|Ciboulette (QS)|Beurre (30 g)|Sel, poivre (QS)",
     "instructions": "Battre les œufs avec les herbes. Faire chauffer le beurre, verser les œufs et cuire selon la texture désirée. Servir chaud.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "semaine",
+    "public": "kids"
   },
   {
     "id": "p84",
@@ -1173,7 +1339,9 @@
     "ingredients": "Farine de sarrasin (250 g)|Eau (500 ml)|Sel (QS)|Œufs (4)|Garniture au choix (jambon, fromage) (QS)",
     "instructions": "Préparer la pâte avec la farine, l’eau et le sel. Cuire les galettes à la poêle et garnir selon les goûts. Replier et servir chaud.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "semaine",
+    "public": "tous"
   },
   {
     "id": "p85",
@@ -1187,7 +1355,9 @@
     "ingredients": "Poulet (500 g)|Courgettes (300 g)|aubergine (300 g)|Poivrons (200 g)|Tomates (400 g)|Oignons (1)|Herbes de Provence (1 c. c.)|Huile olive (3 c. s.)",
     "instructions": "Faire revenir les légumes coupés avec les herbes. Ajouter le poulet en morceaux et laisser mijoter 25 minutes. Servir chaud.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "tous",
+    "public": "tous"
   },
   {
     "id": "p86",
@@ -1201,7 +1371,9 @@
     "ingredients": "pain de mie (8 tranches)|Jambon Herta (4 tranches)|Fromages (emmental ou comté) (150 g)|Beurre (30 g)",
     "instructions": "Beurrer les tranches, garnir de jambon et fromage. Refermer, puis faire griller dans un appareil ou à la poêle jusqu’à ce que le fromage fonde.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "semaine",
+    "public": "kids"
   },
   {
     "id": "p87",
@@ -1215,7 +1387,9 @@
     "ingredients": "Poulet (500 g)|Crème fraîche (200 g)|Champignons (250 g)|Oignons (1)|Ail (2 gousses)|Beurre (30 g)|Sel, poivre (QS)",
     "instructions": "Faire dorer le poulet dans du beurre. Ajouter oignon et ail émincés, puis les champignons. Verser la crème et mijoter 15 minutes. Assaisonner et servir avec des pâtes ou du riz.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "tous",
+    "public": "tous"
   },
   {
     "id": "p88",
@@ -1229,7 +1403,9 @@
     "ingredients": "Poulet (500 g)|Curry (pâte, 2 c. s.)|Lait de coco (400 ml)|Oignons (1)|Ail (2 gousses)|Tomates (200 g)|Huile végétale (2 c. s.)",
     "instructions": "Faire revenir oignon et ail dans l'huile. Ajouter le poulet et la pâte de curry. Incorporer les tomates et le lait de coco. Mijoter 15 minutes. Servir avec du riz.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "tous",
+    "public": "adultes"
   },
   {
     "id": "p89",
@@ -1243,7 +1419,9 @@
     "ingredients": "pain de mie (4 tranches)|Saumon fumé (200 g)|Œufs (4)|avocat (2)|Citron (1)|Aneth (QS)|Sel, poivre (QS)",
     "instructions": "Griller le pain. Écraser l'avocat avec du citron et étaler sur les tartines. Ajouter le saumon fumé et un oeuf poché. Parsemer d'aneth et assaisonner.",
     "type_repas": "entree",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "semaine",
+    "public": "tous"
   },
   {
     "id": "p90",
@@ -1257,7 +1435,9 @@
     "ingredients": "pâte feuilletée (230 g)|fêta (200 g)|Crème fraîche (100 g)|Crème liquide (100 ml)|Tomates fraîches (300 g)|Des olives noires (80 g)|Huile olive (2 c. s.)|Tomates séchées (50 g)|De l’origan (1 c. c.)",
     "instructions": "Étalez la pâte feuilletée et faites-la cuire à 180 degrés pendant 30 minutes, idéalement avec un poids pour qu’elle reste plate. En parallèle, réalisez une crème de feta. Pour cela, disposez la feta émiettée, la crème fraîche et la crème liquide dans un saladier. Montez les ingrédients en sorte de chantilly à l’aide d’un fouet ou d’un batteur. Une fois la pâte feuilletée cuite et légèrement refroidie, ajoutez la crème de feta. Puis, lavez les tomates et coupez-les en rondelles. Placez-les sur la préparation précédente. Parsemez de quelques olives et de quelques tomates séchées. Versez un filet d’huile d’olive et saupoudrez d’origan. C’est prêt, vous n’avez plus qu’à vous régaler.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "semaine",
+    "public": "tous"
   },
   {
     "id": "p91",
@@ -1271,7 +1451,9 @@
     "ingredients": "Beurre (100 g)|Sel (QS)|Eau (QS)|Huile olive (2 c. s.)|Gruyère râpé (150 g)|Poivre (QS)|Basilic séché (1 c. c.)|Moutarde (2 c. s.)",
     "instructions": "Préparer la pâte brisée, en mélangeant la farine et le beurre ramolli du bout des doigts avec le sel. Ajouter peu à peu l'eau jusqu'à obtention d'une boule de pâte ferme, placer 20 min au réfrigérateur. Ou prendre une pâte toute faite ! Pendant ce temps, couper les tomates en deux, bien les répartir dans le moule avec la peau contre le fond. Ne pas hésiter à serrer les tomates car avec la cuisson, elles vont se ratatiner ! Assaisonner de sel et de poivre et d'un filet d'huile d'olive, et enfourner jusqu'à ce qu'elles aient rendu du jus (1/2 h environ). Jeter le jus, puis couvrir de gruyère râpé. Étaler la pâte et la badigeonner de moutarde. Découper un petit cercle au centre de la taille d'une noisette. Recouvrir les tomates de ce disque de pâte brisée, moutarde contre gruyère puis enfourner 30 min. Quand la pâte est cuite, procéder délicatement au démoulage. Parsemer sur votre tarte tatin du basilic ciselé, et servir aussitôt.",
     "type_repas": "plat",
-    "categorie_jour": "semaine"
+    "categorie_jour": "semaine",
+    "moment": "semaine",
+    "public": "tous"
   },
   {
     "id": "p93",
@@ -1285,7 +1467,9 @@
     "ingredients": "Thon (200 g)|Courgettes (400 g)|Fécule de maïs (30 g)|Œufs (4)|Crème légère liquide (200 ml)|Fromage blanc (200 g)",
     "instructions": "Préchauffer le four à 180 °C. Laver et couper les courgettes en rondelles, puis les cuire à la poêle huilée ou à la vapeur selon le goût préféré. Dans un bol, verser le fromage blanc, casser les 4 œufs entiers, puis ajouter la crème et la fécule. Saler et poivrer à convenance. Dans un plat à tarte, émietter le thon au fond, disposer les rondelles de courgettes cuites par-dessus. Verser délicatement l'appareil à quiche sur la garniture. Enfourner pour 35 minutes, vérifier la cuisson régulièrement avec un couteau : le dessus doit être doré à la fin.",
     "type_repas": "plat",
-    "categorie_jour": "semaine"
+    "categorie_jour": "semaine",
+    "moment": "tous",
+    "public": "adultes"
   },
   {
     "id": "p101",
@@ -1299,7 +1483,9 @@
     "ingredients": "Oignons (1)|Des figues (6)|Des feuilles de lasagne (8)|De la ricotta (250 g)|Du zaatar (1 c. c.)|Sel (QS)|Poivre (QS)|De la pistache (60 g)|Huile olive (2 c. s.)|De l'huile pimentée (1 c. s.)",
     "instructions": "Commencez par éplucher et émincer un oignon. Dans une poêle, faites chauffer un filet d’huile d’olive. Déposez-y les morceaux d’oignon. En parallèle, dans un bol, placez la ricotta. Ajoutez un soupçon d’huile d’olive. Puis, dans un autre petit récipient, ajoutez les pistaches concassées, presque en poudre, avec le sel et le poivre. Incorporez le tout dans le fromage. Mélangez à l’aide d’une cuillère. Après avoir lavé les figues, coupez-les en tranches. Réservez les oignons une fois caramélisés et fondants. Dans la poêle, faites revenir les morceaux de figues quelques instants. Dans une casserole, faites bouillir de l’eau et faites-y cuire les feuilles de lasagnes. Récupérez-les une à une et réalisez le montage de vos lasagnes. Dans une assiette, disposez une feuille de lasagne, par-dessus, mettez une cuillère de garniture à la ricotta. Ajoutez les oignons et les tranches de figues. Saupoudrez d’un peu de pistaches concassées. Ajoutez une seconde feuille de lasagne et recommencez les étapes précédentes. Terminez avec une couche de fromage avec des morceaux de fruits et quelques fruits secs concassés. Versez un filet de chili oil pour la touche finale. Bon appétit !",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "tous",
+    "public": "adultes"
   },
   {
     "id": "p102",
@@ -1313,7 +1499,9 @@
     "ingredients": "Oignons (2)|Laurier (2 feuilles)|Sel (QS)|Poivre (QS)|Poulet (entier, 1.2 kg)|Ail (2 gousses)|Citron (1)|Bouillon cube (1)",
     "instructions": "Préchauffer le four à 200°C, placer deux gousses d'ail et des feuilles de laurier à l'intérieur du poulet, préparer une sauce en mélangeant le jus de citron et le bouillon de poulet, verser sur le poulet et le reste dans le plat, saupoudrer de sel gros sur le poulet, placer dans le plat avec des oignons en quartiers et des tomates cerises, cuire environ 1 heure 40 minutes à 200°C, retourner le poulet après 20 minutes puis à nouveau après 20 minutes, arroser fréquemment avec son jus pendant la cuisson, ajouter de l'eau si nécessaire, et enfin servir le jus avec les tomates et oignons dans un bol, accompagné d'une salade verte et d'une poêlée de pommes de terre nouvelles.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "semaine",
+    "public": "tous"
   },
   {
     "id": "p103",
@@ -1327,7 +1515,9 @@
     "ingredients": "Oignons (2)|Thym (1 c. c.)|Poivre (QS)|Sel (QS)|Huile olive (2 c. s.)|Saucisses fumées (8, ~600 g)|Ail (3 gousses)|Laurier (2 feuilles)",
     "instructions": "Piquer les saucisses et les faire bouillir pendant 10 minutes dans la même casserole qui sera utilisée pour le plat afin de conserver les saveurs, ensuite vider la casserole, réserver les saucisses et faire chauffer l'huile d'olive dedans, faire revenir les oignons émincés et l'ail écrasé sans les faire brunir, couper les saucisses en morceaux de 1,5 cm et les faire cuire avec les oignons pendant 5 minutes, puis ajouter les tomates hachées et les aromates incluant du piment, enfin mélanger le tout et laisser mijoter à feu doux, en retirant occasionnellement le couvercle pour évaporer l'excès d'eau, et servir avec du riz thaï.",
     "type_repas": "plat",
-    "categorie_jour": "semaine"
+    "categorie_jour": "semaine",
+    "moment": "tous",
+    "public": "adultes"
   },
   {
     "id": "p104",
@@ -1341,7 +1531,9 @@
     "ingredients": "Oignons (1)|Thym (1 c. c.)|Laurier (2 feuilles)|Huile olive (2 c. s.)|Poulet (cuisses, 4, ~800 g)|Eau (100 ml)|Ail (4 gousses)|Bouillon cube (1)|Genièvre (6 baies)",
     "instructions": "Préchauffer le four à 210°C, placer les cuisses de poulet dans un plat allant au four, ajouter l'oignon en quartiers, l'ail, le thym, les feuilles de laurier, le cube de bouillon émietté en quartiers, les baies de genièvre et un clou de girofle, puis verser l'eau et arroser d'huile d'olive. Cuire à 210°C pendant 35 minutes, en arrosant de temps en temps.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "semaine",
+    "public": "tous"
   },
   {
     "id": "p105",
@@ -1355,7 +1547,9 @@
     "ingredients": "Huile olive (2 c. s.)|Paupiettes de veau (4, ~600 g)|Fond de veau (1 c. c. ou 1 tablette, QS)|Ail (2 gousses)|Vin blanc (100 ml)|Eau (100 ml)|Moutarde (1 c. c.)|Vinaigre balsamique (1 c. s.)",
     "instructions": "Chauffer l'huile d'olive et l'ail finement haché dans une sauteuse à feu moyen, faire dorer les paupiettes de veau sur tous les côtés, ajouter le fond de veau et déglacer avec le vin blanc et l'eau, puis incorporer la moutarde et le vinaigre balsamique, en veillant à ce que les paupiettes soient bien enrobées. Cuire 5 minutes pour évaporer l'alcool, puis laisser mijoter à couvert à feu doux pendant environ 20 minutes, en retournant les paupiettes de temps en temps, et servir avec des légumes ou des accompagnements féculents.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "tous",
+    "public": "adultes"
   },
   {
     "id": "p106",
@@ -1369,7 +1563,9 @@
     "ingredients": "poireaux (2)|Oignons (1, piqué de clous de girofle)|Poivre (QS)|Sel (QS)|Bœuf (à braiser, 800 g)|Os à moelle (4)|Rave ou navets (300 g)|céleri (1 branche)|Ail (2 gousses)|Bouquet garni (1)",
     "instructions": "Laver et éplucher tous les légumes, les couper en gros morceaux, piquer l'oignon entier avec des clous de girofle, faire bouillir 3 litres d'eau, puis ajouter tous les légumes, le bouquet garni, l'ail, le sel, le poivre et la viande, cuire environ 2 heures 30 minutes à 3 heures, en écumant de temps en temps, ajouter les os à moelle 1 heure avant la fin, en maintenant la moelle avec du gros sel, enfin égoutter les légumes et la viande, et servir chaud avec de la moutarde.",
     "type_repas": "plat",
-    "categorie_jour": "semaine"
+    "categorie_jour": "semaine",
+    "moment": "we",
+    "public": "adultes"
   },
   {
     "id": "p107",
@@ -1383,7 +1579,9 @@
     "ingredients": "Huile de tournesol (2 c. s.)|Sel (QS)|Poivre (QS)|Veau (rôti, 800 g)|Ail (3 gousses)|Champignons (250 g)",
     "instructions": "Faire de petites incisions dans le rôti et y insérer des lamelles d'ail, préchauffer le four 10 minutes à 210°C (thermostat 7), placer les champignons et leur jus dans un plat allant au four, ajouter le rôti entouré de morceaux d'ail, arroser d'huile de tournesol, ajouter 10 cl d'eau, et cuire 1 heure 30 minutes (30 minutes par livre) en retournant à mi-cuisson et en vérifiant le niveau de jus, puis laisser reposer 10 minutes dans le four éteint, enfin assaisonner de sel et poivre, et servir avec des pommes de terre ou des petits pois.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "we",
+    "public": "adultes"
   },
   {
     "id": "p108",
@@ -1397,7 +1595,9 @@
     "ingredients": "Margarine ou beurre (30 g)|Sel (QS)|Poivre (QS)|Moules (2 kg)|Échalotes (2)|Vin blanc sec (200 ml)|Farine (1 c. c.)|Persil (QS)",
     "instructions": "Hacher les échalotes, gratter et laver les moules, puis les cuire dans une casserole couverte avec du beurre, les échalotes hachées et le vin blanc à feu vif pendant quelques minutes, en remuant 2 ou 3 fois jusqu'à ce qu'elles s'ouvrent, retirer les moules en conservant le jus de cuisson, et les placer dans un plat chaud, réchauffer le jus, mélanger une cuillère à café de farine avec une quantité égale de beurre ou margarine et l'incorporer au jus, en portant à ébullition brièvement, puis assaisonner de sel et poivre, enfin verser la sauce sur les moules, saupoudrer de persil haché, et servir.",
     "type_repas": "plat",
-    "categorie_jour": "semaine"
+    "categorie_jour": "semaine",
+    "moment": "we",
+    "public": "adultes"
   },
   {
     "id": "p109",
@@ -1411,7 +1611,9 @@
     "ingredients": "Agneau (gigot, 1.8 kg)|Ail (6 gousses)|Romarin (QS)|Sel (gros, QS)",
     "instructions": "Chauffer le four à Th 7/8, retirer la graisse du gigot avec un couteau pour exposer la chair, faire une pâte avec la graisse, l'ail écrasé, les feuilles de romarin et du sel gros, masser cette pâte dans la viande, placer au four, et arroser toutes les 15 minutes avec un mélange d'eau chaude et de graisse, pour ceux qui aiment l'ail confit, ajouter des gousses d'ail non pelées au fond du plat.",
     "type_repas": "plat",
-    "categorie_jour": "semaine"
+    "categorie_jour": "semaine",
+    "moment": "we",
+    "public": "adultes"
   },
   {
     "id": "p110",
@@ -1425,7 +1627,9 @@
     "ingredients": "pâte feuilletée (230 g)|Oignons (1)|Courgettes (300 g)|aubergine (300 g)|Poivrons (200 g)|1 fenouil|Tomates (coulis, 300 g)|Sauce soja (1 c. s.)|Sauce hoisin (1 c. s.)|Huile olive (2 c. s.)|Sel (QS)|Poivre (QS)|Parmesan (60 g)",
     "instructions": "Commencez par faire sauter les légumes séparément dans un filet d’huile d’olive. Égouttez-les, puis laissez-les compoter doucement avec du coulis de tomate, une cuillère de sauce soja et une cuillère de sauce hoisin. Quand votre ratatouille est cuite, vous allez pouvoir passer à la suite. Étalez la pâte feuilletée sur une plaque et répartissez les légumes dessus en laissant 1 cm de bord vide, comme conseillé par le chef. Saupoudrez généreusement de parmesan râpé et enfournez à 180 °C pendant 30 à 40 min. Vous n'avez plus qu'à attendre !",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "semaine",
+    "public": "tous"
   },
   {
     "id": "p111",
@@ -1439,7 +1643,9 @@
     "ingredients": "Riz (arborio, 300 g)|Échalotes (2)|Ail (2 gousses)|Thym (1 c. c.)|Vin blanc sec (100 ml)|Bouillon cube (2, ~1 L d'eau chaude)|Tomates concassées (300 g)|Parmesan (60 g)|Ricotta (80 g, pour le risotto)|Huile olive (3 c. s.)|aubergine (400 g)|Ricotta (60 g, pour le dressage)|Parmesan (30 g, pour le dressage)|Poivre (QS)|Basilic (frais, QS)",
     "instructions": "Lavez et séchez l'aubergine avant de la découper en petits cubes. Faites chauffer de l'huile d'olive dans une sauteuse avant d'y ajouter l'aubergine. Laissez cuire à feu moyen jusqu'à ce que l'aubergine soit dorée et fondante. Assaisonnez avec le sel et le poivre avant de réserver. Pelez l'échalote et émincez-la. Pelez l'ail, ôtez le germe puis écrasez-le au presse-ail. Faites revenir l'ail et l'échalote dans une sauteuse avec un peu d'huile d'olive. Ajoutez ensuite le riz et laissez-le prendre une couleur légèrement nacrée. Arrosez de vin blanc et remuez bien. Une fois le liquide évaporé, versez le bouillon de légumes, louche par louche, en attendant qu'il soit bien absorbé avant d'en ajouter. Une fois le riz quasiment cuit (il ne faut pas qu'il soit trop mou), intégrez les tomates concassées, mélangez et laissez mijoter quelques minutes. Ajoutez la ricotta, le parmesan râpé ainsi que les 2/3 des cubes d'aubergine. Mélangez bien. Servez ce risotto bien chaud dans une assiette creuse en décorant avec le reste de l'aubergine. Déposez une quenelle de ricotta au centre et parsemez de basilic lavé, séché, et fraîchement ciselé. Terminez avec un peu de parmesan, un filet d'huile d'olive et un tour de moulin à poivre.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "we",
+    "public": "adultes"
   },
   {
     "id": "p112",
@@ -1453,7 +1659,9 @@
     "ingredients": "aubergine (400 g)|Tomates (400 g)|Beurre (60 g)|Farine (100 g)|Sucre (1 c. c.)|Sel (QS)|Poivre (QS)|mozzarella (200 g)|Chapelure (40 g)|Pignons de pin (30 g)|Parmesan (60 g)|Huile olive (2 c. s.)",
     "instructions": "Commencez par chauffer votre four à 180 °C (thermostat 6). Coupez les aubergines en petits cubes et faites-les revenir dans une casserole avec de l’huile d’olive pendant 10 min. Ajoutez ensuite les tomates coupées en dés, une pincée de sucre, du sel et du poivre, puis laissez mijoter doucement pendant 15 min. Pendant ce temps, préparez le crumble. Émiettez du beurre froid avec la farine et la chapelure, puis incorporez le parmesan râpé et les pignons de pin. Coupez la mozzarella en petits morceaux. Répartissez les légumes cuits dans un grand plat ou des portions individuelles. Parsemez la mozzarella sur le dessus, puis recouvrez avec le mélange crumble. Terminez par un filet d’huile d’olive avant d’enfourner. Laissez cuire environ 50 min jusqu’à obtenir une belle croûte dorée. Servez aussitôt, chaud et savoureux.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "semaine",
+    "public": "kids"
   },
   {
     "id": "p113",
@@ -1467,7 +1675,9 @@
     "ingredients": "pâte brisée (230 g)|Lardons (150 g)|Emmental (100 g)|Crème fraîche (150 g)|Huile (2 c. s.)|Oignons (1)|Œufs (3)",
     "instructions": "Peler les courgettes et l'oignon, les couper en dés et les faire revenir dans l'huile avec les lardons. Dérouler la pâte dans un moule à tartes et la piquer avec une fourchette. Mélanger la crème et l'oeuf. Saler et poivrer. Disposer sur la pâte les courgettes, l'oignon et les lardons, puis la préparation. Saupoudrer d'emmental et enfourner pendant 20 mn environ à four chaud. (180°C, Th 6).",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "semaine",
+    "public": "tous"
   },
   {
     "id": "p114",
@@ -1481,7 +1691,9 @@
     "ingredients": "Poivre (QS)|Sel (QS)|Huile olive (3 c. s.)|pâte feuilletée (230 g)|mozzarella (200 g)|Herbes de Provence (1 c. c.)|Basilic (frais, QS)",
     "instructions": "Laver et couper aubergine et courgettes en dés sans les éplucher, puis les faire revenir dans une poêle à l'huile d'olive. A mi-cuisson (les légumes ont commencé à perdre leur eau), ajouter les tomates lavées et coupées en rondelles épaisses. Ajouter herbes de provence, sel et poivre. Tapisser le moule à tarte de pâte feuilletée, y verser les légumes lorsqu'ils sont dorés. Répartir des rondelles de mozzarella sur le dessus. Parsemer de feuilles de basilic ciselées. Faire cuire 20 mn à four chaud, jusqu'à ce que la pâte soit dorée et la mozzarella bien fondue.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "semaine",
+    "public": "tous"
   },
   {
     "id": "p115",
@@ -1495,7 +1707,9 @@
     "ingredients": "Lardons (150 g)|Crème fraîche (150 g)|Gruyère râpé (120 g)|Poivre (QS)|Sel (QS)|Coquillettes (350 g)|Champignons (200 g)|Tomates (200 g)",
     "instructions": "Cuire les coquillettes à l'eau salée. Pendant ce temps, faire revenir les lardons. Couper la tomate en dés et les champignons en lamelles. Mélanger dans un plat à gratin les légumes, les lardons et les pâtes. Ajouter la crème fraîche. Terminer par une généreuse couche de gruyère râpé. Enfourner à four chaud (Th7) et laisser cuire jusqu'à ce que le gruyère prenne une jolie couleur dorée.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "semaine",
+    "public": "kids"
   },
   {
     "id": "p116",
@@ -1509,7 +1723,9 @@
     "ingredients": "Œufs (8)|Yaourts grecs (2 pots, ~400 g)|Huile olive (2 c. s.)|Paprika (1 c. c.)|Sel (QS)",
     "instructions": "Commencez par faire chauffer une poêle propre, sans matière grasse, en la plaçant sur feu doux. Pendant ce temps, cassez les œufs dans un bol si vous préférez les battre à l’avance, ou bien cassez-les directement dans la poêle. Une fois que la poêle est bien chaude, versez les œufs et commencez immédiatement à les mélanger sans interruption à l’aide d’une spatule ou d’une cuillère en bois. Continuez à remuer doucement jusqu’à ce que les œufs prennent une consistance crémeuse et légèrement prise. Dès que la cuisson vous semble parfaite, retirez-les du feu. Dans une assiette creuse, étalez généreusement du yaourt grec bien épais. Arrosez d’un filet d’huile d’olive. Salez légèrement, saupoudrez de paprika doux, et parsemez de quelques feuilles de romarin. Transférez les œufs sur le yaourt assaisonné. Mélangez délicatement, puis dégustez accompagné d’une belle tranche de pain frais ou grillé. Vous pouvez directement vous servir dans le plat à l’aide de ce morceau de pain, comme le fait le créateur de contenus en vidéo.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "semaine",
+    "public": "kids"
   },
   {
     "id": "p117",
@@ -1523,7 +1739,9 @@
     "ingredients": "Oignons (1)|Thym (1 c. c.)|Poivre (QS)|Sel (QS)|Beurre (20 g, pour le moule)|Huile olive (2 c. s.)|Tomates pelées (400 g)|Ail (2 gousses)|Thon (200 g)|Œufs (4)",
     "instructions": "Retirer la peau des oignons, puis découper en petits morceaux. Verser un filet d’huile d’olive dans une poêle et faire revenir doucement les oignons hachés à feu doux jusqu’à ce qu’ils deviennent translucides et légèrement fondants. Pendant ce temps, écraser grossièrement les tomates pelées à l’aide d’une fourchette. Une fois les oignons bien attendris, incorporer les tomates, ajouter les gousses d’ail finement émincées et la branche de thym. Laisser mijoter cette préparation pendant une quinzaine de minutes en remuant de temps en temps. Égoutter soigneusement le thon puis l’émietter à l’aide d’une fourchette. Dans un saladier, battre les œufs, saler et poivrer à convenance. Incorporez le thon au mélange d’œufs, puis remuer jusqu’à obtenir une préparation homogène. Graisser un moule avec du beurre, verser-y la préparation, puis enfourner à 240 °C (thermostat 8) pendant environ 45 minutes. Laisser refroidir quelques instants et déguster.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "we",
+    "public": "adultes"
   },
   {
     "id": "p118",
@@ -1537,7 +1755,9 @@
     "ingredients": "Laitue (1 belle salade)|Poulet (émincé, cuit, 400 g)|Croûtons (100 g)|Parmesan (60 g)|Sauce César (150 ml)|Œufs (2, durs)|Ail (1 gousse, pour les croûtons, optionnel)",
     "instructions": "Mélanger la laitue avec la sauce César. Ajouter le poulet émincé, les croûtons et le parmesan râpé. Garnir d'un oeuf dur et servir immédiatement.",
     "type_repas": "entree",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "semaine",
+    "public": "tous"
   },
   {
     "id": "p119",
@@ -1551,7 +1771,9 @@
     "ingredients": "Beurre (130 g)|Farine (200 g)|poireaux (500 g)|Lardons (150 g)|Fromage râpé (gruyère) (100 g)|Crème fraîche (150 g)|Poivre (QS)|Sel (QS)|Eau (QS)|Œufs (3)",
     "instructions": "Préchauffer le four à 210°C (thermostat 7). Faire la pâte à tarte : malaxer le beurre et la farine, l'eau, étaler puis mettre dans le plat. Émincer les poireaux. Les faire dorer dans un peu de beurre. Faire dorer les lardons à part. Les égoutter soigneusement avant de les ajouter aux poireaux. Faire l'appareil : mêler les oeufs, la crème, le sel et le poivre. Étaler les poireaux et les lardons sur la pâte. Parsemer de gruyère râpé, couvrir avec l'appareil. Mettre au four 25 min.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "tous",
+    "public": "tous"
   },
   {
     "id": "p120",
@@ -1565,7 +1787,9 @@
     "ingredients": "Thon (300 g)|haricots verts (300 g)|Tomates (300 g)|Œufs (4)|Olives noires (80 g)|Anchois (8 filets)|Vinaigre (1 c. s.)|Huile olive (3 c. s.)",
     "instructions": "Cuire les haricots verts et les oeufs. Disposer sur une assiette avec le thon, tomates, olives et anchois. Arroser de vinaigrette et servir frais.",
     "type_repas": "entree",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "tous",
+    "public": "tous"
   },
   {
     "id": "p121",
@@ -1579,7 +1803,9 @@
     "ingredients": "Courgettes (500 g)|Œufs (3)|avocat (2)|Farine (30 g, optionnel)|Ail (1 gousse)|Herbes (QS)|Huile olive (2 c. s.)",
     "instructions": "Râper les courgettes et mélanger avec oeufs et herbes. Former des galettes et cuire à la poêle dans l'huile. Servir avec de l'avocat écrasé.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "semaine",
+    "public": "tous"
   },
   {
     "id": "p122",
@@ -1593,7 +1819,9 @@
     "ingredients": "Canard (2 magrets, ~700 g)|Poivre (QS)",
     "instructions": "Préchauffez le four à 250°C (thermostat 8). Poser les magrets (peau sur le dessus) dans un plat à four. Mettre les magrets dans le four chaud pendant 15 min. Sortir et retourner les magrets puis cuire 15 min à 180°C (thermostat 6).",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "we",
+    "public": "adultes"
   },
   {
     "id": "p123",
@@ -1607,7 +1835,9 @@
     "ingredients": "Harissa (1 c. c.)|Huile olive (3 c. s.)|Poivre (QS)|Fleur de sel (QS)|Thym (QS)|Agneau (épaule, 1.2 kg)|Échalotes (2)|Ail (4 gousses)",
     "instructions": "Dans un bol, mélangez huile d'olive, harissa, fleur de sel et poivre. Badigeonnez la viande avec le mélange. Mettez la viande dans un plat avec les herbes aromatiques. Couvrez d'une feuille d'aluminium et faites cuire 45 min dans un four préchauffé à 180°C (thermostat 6). Au bout de 45 min ajoutez l'ail et l'échalote. Couvrez à nouveau, baissez la température à 150°C (thermostat 5), et faites cuire encore 45 min en arrosant de temps en temps avec son jus. Au bout de 45 min, retirez la feuille d'aluminium et laissez dorer environ 30 min.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "we",
+    "public": "adultes"
   },
   {
     "id": "p124",
@@ -1621,7 +1851,9 @@
     "ingredients": "Oignons grelots (12)|Cognac (3 c. s.)|Beurre (40 g)|Huile d'arachide (2 c. s.)|Sel (QS)|Poivre (QS)|Piment (QS)|Queue de lotte (800 g)|Tomates (400 g, en boîte)|Concentré de tomate (2 c. s.)|Échalotes (4)|Ail (1 gousse)|Vin blanc sec (200 ml)",
     "instructions": "Pelez et hachez les 4 échalotes. Pelez et pressez la gousse d'ail. Pelez la douzaine d'oignons grelots. Ouvrez la boîte de tomates et coupez-les. Délayez le concentré de tomates dans les 20 cl de vin blanc. Dans une cocotte en fonte, faites chauffer le beurre et l'huile et y faire colorer à feu vif les tranches de lotte. Flambez-les avec le Cognac puis retirez et placez sur une assiette. Mettez à la place les échalotes, l'ail, les oignons, les tomates et le vin dans lequel est délayé le concentré de tomates. Salez, poivrez, ajoutez le piment et laissez mijoter environ 20 min à découvert. Remettez la lotte dans la sauce, couvrez et laissez cuire encore 20 min. Accompagnez de légumes, pommes de terre et carottes cuites vapeur.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "we",
+    "public": "adultes"
   },
   {
     "id": "p125",
@@ -1635,7 +1867,9 @@
     "ingredients": "Oignons (2)|Thym (QS)|Huile olive (2 c. s.)|Sel (QS)|Poivre (QS)|Bar entier (1, ~1.2 kg)|Citron (1)|Laurier (2 feuilles)|Vin blanc sec (100 ml)|Tomates (300 g)",
     "instructions": "Préchauffer le four à 180°C (thermostat 6). Huiler un plat à four rectangulaire dont la diagonale correspond à la taille du poisson. Disposer sur cette diagonale la moitié du citron coupé en rondelles, poser le poisson dessus après lui avoir rempli le ventre de thym et laurier. Répartir le reste des tranches de citron sur le poisson. De part et d'autre du poisson, mettre l'oignon en rondelles et les tomates coupées en deux, face bombée vers le dessus. Saler, poivrer et arroser d'un filet d'huile d'olive. Enfourner pour 10 mn, puis arroser avec le vin blanc et poursuivre la cuisson 10-15 mn. Répartir le poisson, les tomates et oignons dans des assiettes chaudes, arroser du jus de cuisson.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "we",
+    "public": "adultes"
   },
   {
     "id": "p126",
@@ -1649,7 +1883,9 @@
     "ingredients": "Oignons (1)|Tabasco (QS)|Poivre (QS)|Sel (QS)|Huile olive (2 c. s.)|Bœuf (filet, 600 g)|Œufs (4, jaunes)|Câpres (2 c. s.)|Sauce worcestershire (1 c. s.)|Ketchup (2 c. s.)|Moutarde de Dijon (1 c. c.)|Persil (QS)",
     "instructions": "Couper la viande au couteau (en brunoise). Dans un bol, mélanger le jaune d’œuf, la moutarde de Dijon, l'oignon, les câpres, la Worcestershire sauce, le ketchup, le tabasco, le sel et le poivre. Ajouter l'huile d'olive en remuant avec le fouet. Ajouter la viande à la sauce ainsi que le persil. Rectifier l'assaisonnement. Réfrigérer ou servir immédiatement.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "we",
+    "public": "adultes"
   },
   {
     "id": "p127",
@@ -1663,7 +1899,9 @@
     "ingredients": "Beurre (40 g)|Poivre (QS)|Sel (QS)|Rosbif (800 g)|Ail (1 gousse)",
     "instructions": "Pelez la gousse et coupez la en plusieurs lamelles. Piquez le rôti et glisser les lamelles. Badigeonnez le rôti de beurre ramolli. Saisir le rôti au four très chaud pendant 7 à 8 min, puis ramener la température à 220°C. Laissez cuire pendant 20 à 25 min pour un rôti saignant (+4 min pour un rôti à point). Salez et poivrez en fin de cuisson. Arrêtez le four et laissez le rôti reposer 6 à 8 min en laissant la porte entre ouverte. Sortez le rôti, le découper en fines tranches, le déposer dans un plat chaud. Dans le plat de cuisson, ajoutez un verre d'eau et grattez les sucs de cuisson. Faites chauffer cette sauce sur une source de chaleur directe. Plus qu'à napper les tranches de rosbeef ! Bon appétit !",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "we",
+    "public": "adultes"
   },
   {
     "id": "p128",
@@ -1677,7 +1915,9 @@
     "ingredients": "Huile olive (6 c. s.)|Poivre (QS)|Sel (QS)|Crevettes (600 g)|Ail (4 gousses)|Persil (QS)|Piment doux (QS)",
     "instructions": "Lavez et essuyez les crevettes. Faites chauffer 4 cuillères à soupe d'huile dans 1 grande poêle. Ajoutez les crevettes et faites les cuire 5 mn de chaque côté puis sortez les de la poêle. Passez l'ail au mixeur, le persil et le piment doux. Dans la poêle, versez le reste de d'huile puis ajoutez l'ail, le persil et le piment. Remuez bien, pour que l'ail soit cuit mais non brûlé. Remettez les crevettes à chauffer. Salez, poivrez et servez chaud.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "tous",
+    "public": "adultes"
   },
   {
     "id": "p129",
@@ -1691,7 +1931,9 @@
     "ingredients": "Oignons (2)|Poivre (QS)|Sel (QS)|Poulet (blancs, 500 g)|Crème fraîche (150 g)|Curry (1 c. s.)|Cumin (1 c. c.)",
     "instructions": "Mettre une grande poêle à chauffer. Couper les oignons en petits morceaux, et les faire cuire à feu assez fort. Remuer, en ajoutant du curry et du cumin. Couper les blancs de poulet en morceaux, les ajouter dans la poêle et remettre des épices, tourner. Baisser le feu, et ajouter 2 cuillères à soupe de crème. Après 5 min de cuisson, remettre 2 cuillères à soupe de crème et des épices (si nécessaire). Si le plat est fait à l'avance, remettre un peu de crème au moment de réchauffer car la sauce s'évapore. Bon appétit.",
     "type_repas": "plat",
-    "categorie_jour": "semaine"
+    "categorie_jour": "semaine",
+    "moment": "semaine",
+    "public": "tous"
   },
   {
     "id": "p130",
@@ -1705,7 +1947,9 @@
     "ingredients": "Oignons (2)|Poivre (QS)|Sel (QS)|Poulet (morceaux, 800 g)|Huile d'arachide (2 c. s.)|Pâte d'arachide (200 g)|Concentré de tomate (2 c. s.)|Pommes de terre (400 g)|Patates douces (300 g)|Ail (2 gousses)|Piment oiseau (QS)|Piments antillais (2, entiers, non écrasés)|Eau (500 ml)",
     "instructions": "Faire revenir le poulet dans l'huile d'arachide bien chaude. Les réserver (les retirer du feu). Faire revenir les oignons et le piment oiseau jusqu'à coloration. Rajouter ensuite la tomate concentrée et les deux gousses d'ail (ciselé). Laisser cuire 2 mn. Rajouter l'eau, les pommes de terre et les patates douces. Laisser cuire pendant 20 mn. Rajouter ensuite la pâte d'arachide, assaisonner (sel poivre). Après 2 mn de cuisson ajouter le netetou et laisser cuire jusqu'à épaississement de la sauce (bien consistant). Remettre le poulet dans la sauce avec les deux piments antillais (sans les écraser surtout !). Laisser cuire à feu doux et à semi couvert pendant 30 mn.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "we",
+    "public": "adultes"
   },
   {
     "id": "p131",
@@ -1719,7 +1963,9 @@
     "ingredients": "Bouillon cube (2)|Gingembre (1 c. s., moulu)|Sucre (100 g)|Oignons (1)|Filet mignon (600 g)|Eau (500 ml + QS pour le caramel)|Épices (mélange 4 épices, 1 c. s.)|Sauce soja (3 c. s.)",
     "instructions": "Découper le porc en bouchées. Faire chauffer 50 cl d'eau. Ajouter les deux cubes de bouillon de poule, 1 cuillère à soupe de gingembre moulu, 1 cuillère à soupe de mélange quatre épices et 3 cuillères à soupe de sauce soja. Dans une sauteuse, préparez votre caramel avec le sucre et l'eau. Une fois le caramel prêt, ajouter le bouillon et tourner très vite pour faire dissoudre le caramel dans le bouillon. Une fois le caramel dissout, rajouter la viande et l'oignon coupé en gros morceaux et mettre à feu très vif. Laisser réduire jusqu'à ce que tout le liquide se soit évaporé (environ 25 min) et que la viande se mêle au mélange épais caramel-épices. Déguster !",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "we",
+    "public": "adultes"
   },
   {
     "id": "p132",
@@ -1733,7 +1979,9 @@
     "ingredients": "Oignons (1)|poireaux (300 g)|Huile (2 c. s.)|Champignons (200 g)|Nouilles chinoises (300 g)|Épices (mélange 5 épices, 1 c. c.)|Sauce soja (3 c. s.)",
     "instructions": "Détailler tous les légumes en fine julienne. Faire bouillir une grande casserole d'eau salée, y jeter les nouilles, dès que l'ébullition à repris, couvrir, éteindre le feu et laisser reposer pendant 4 min. Pendant ce temps, faire revenir les légumes dans l'huile pendant 5 mn, à feu très vif, ajouter les cinq épices et la sauce de soja. Égoutter les nouilles, les joindre aux légumes et rectifier l'assaisonnement si besoin.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "semaine",
+    "public": "tous"
   },
   {
     "id": "p133",
@@ -1747,7 +1995,9 @@
     "ingredients": "Oignons (1)|Crème fraîche (100 g)|Sel (QS)|Poivre (QS)|Muscade (QS)|Canard (cuisses confites, 4)|Échalotes (2)|Pommes de terre (800 g)|Lait (150 ml)|Eau (150 ml)",
     "instructions": "Lavez et épluchez les pommes de terre, et mettez-les à cuire dans un grand volume d'eau salée. Réchauffez les cuisses de canard au bain-marie pour les extraire de leur graisse. Conservez une cuillère à soupe de graisse de canard. Découpez et hachez grossièrement les cuisses confites (surtout pas de mixer !). Emincer les échalotes et les oignons. Dans une large poêle ou une sauteuse, faites blondir les oignons et les échalotes hachés dans la cuillère à soupe de graisse de canard, à feu très doux. Lorsque ce mélange oignons + échalotes est bien blond, ajoutez le hachis de canard et mettez à feu vif, en mélangeant vivement, pendant 5 minutes. Le hachis de canard doit être finement grillé en surface, mais rester moelleux. Réservez hors du feu. Ecrasez vos pommes de terre à la fourchette (pitié, pas de presse-purée !) et faites une purée moelleuse en ajoutant 50 % d'eau et 50 % de lait. Salez, poivrez, ajoutez une pincée de muscade et la crème fraîche. Préchauffez le four à 200°C (thermostat 6-7). Dans un plat suffisamment haut, étalez la moitié de votre hachis de canard. Mélangez la moitié qui reste avec le même volume de purée, et étalez cette deuxième couche sur la première. Finissez par une troisième couche de purée. Striez le sommet de votre purée avec le dos d'une fourchette. Laissez cuire à four chaud (200°C) pendant 25 min. Vous pouvez également finir la cuisson 3 minutes sous le gril pour obtenir un joli gratiné. Servez avec une salade (mâche, par exemple) et un Cahors léger : ce plat ne paye pas de mine, mais vos convives seront très agréablement surpris !",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "we",
+    "public": "adultes"
   },
   {
     "id": "p134",
@@ -1761,7 +2011,9 @@
     "ingredients": "Oignons (1)|Poivre (QS)|Sel (QS)|Ail (2 gousses)|Beurre (30 g)|Bouillon cube (1)|Joue de bœuf (400 g)|Paleron (400 g)|Carottes (500 g)|Concentré de tomate (1 c. s.)|Vin blanc (150 ml)",
     "instructions": "Faire fondre le beurre dans une cocotte, y faire revenir la viande. Incorporer les oignons avec l'ail, le sel et le poivre. Déglacer avec le vin blanc, gratter les sucs de cuisson puis rajouter le concentré de tomate. Emietter les cubes de bouillon dans la cocotte et mouiller avec un peu d'eau. Laisser cuire 1h15. Rajouter les carottes pelées et coupées en rondelles et prolonger la cuisson 45 minutes.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "semaine",
+    "public": "tous"
   },
   {
     "id": "p135",
@@ -1775,7 +2027,9 @@
     "ingredients": "Oignons (2)|Thym (QS)|Laurier (2 feuilles)|Huile (2 c. s.)|Beurre (30 g)|Poulet (entier, 1.2 kg)|Ail (4 gousses)|Bouillon cube (1)|Eau (200 ml)",
     "instructions": "Préparer le poulet en le nettoyant et en le farcissant avec un oignon coupé en quatre, des feuilles de laurier et du thym. Saler et poivrer l'intérieur et l'extérieur. Préchauffer le four à 200°C. Faire fondre beurre et huile dans une cocotte, colorer le poulet sur toutes faces. Ajouter un oignon en rondelles, des feuilles de laurier, du thym, et des gousses d'ail écrasées, puis le bouillon de volaille. Enfourner la cocotte fermée pendant 2h, en tournant le poulet à mi-cuisson. Après cuisson, découper le poulet, réduire le bouillon restant si nécessaire, et déglacer avec de l'eau pour le jus.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "semaine",
+    "public": "kids"
   },
   {
     "id": "p136",
@@ -1789,7 +2043,9 @@
     "ingredients": "Poivre (QS)|Sel (QS)|Huile olive (4 c. s.)|Poulet (blancs, 500 g)|Citron (1)|Ail (2 gousses)|Vinaigre balsamique (2 c. s.)|Miel (2 c. s.)|Sauce soja (QS, cf. signalement)",
     "instructions": "Mélanger dans un saladier le citron, l'huile d'olive, le vinaigre balsamique et le miel. Couper l'ail finement, l'ajouter à la marinade et mélanger. Ajouter les blancs de poulet coupés en cubes. Laisser mariner au moins 2h.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "semaine",
+    "public": "tous"
   },
   {
     "id": "p137",
@@ -1803,7 +2059,9 @@
     "ingredients": "Farine de sarrasin (250 g)|Beurre (40 g)|Huile (1 c. s.)|Sel (QS)|Poivre (QS)|Œufs (6 : 2 pour la pâte + 4 pour la garniture)|Lait (400 ml)|Eau (200 ml)|Gruyère râpé (150 g)|Jambon Herta (4 tranches)",
     "instructions": "Verser la farine dans un saladier, faire un puits, y casser 2 oeufs, fouetter en ajoutant progressivement le lait et l'eau, puis ajouter le beurre fondu, poivrer et saler légèrement. Laisser reposer 2h. Chauffer une poêle à crêpes avec de l'huile, verser la pâte, cuire un côté, retourner, casser un oeuf dessus, poivrer, ajouter gruyère râpé et une tranche de jambon, rabattre deux côtés et replier les deux autres. Répéter jusqu'à épuisement de la pâte. Servir avec une salade verte.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "semaine",
+    "public": "kids"
   },
   {
     "id": "p138",
@@ -1817,7 +2075,9 @@
     "ingredients": "Oignons (1)|Sel (QS)|Poivre (QS)|Huile olive (2 c. s.)|Poulet (aiguillettes, 500 g)|Crème (200 ml)|Citron (1)",
     "instructions": "Mélanger crème, jus de citron, sel et poivre dans un bol, réserver. Chauffer l'huile dans une sauteuse, y faire revenir l'oignon émincé 1-2 min. Ajouter les aiguillettes, saler, poivrer, cuire à couvert 10 min. Retourner les aiguillettes avec une fourchette, cuire encore 5-10 min à couvert. Arrêter le feu, verser la crème au citron, assaisonner si besoin. Servir avec du riz et des courgettes sautées ou vapeur.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "semaine",
+    "public": "tous"
   },
   {
     "id": "p139",
@@ -1831,7 +2091,9 @@
     "ingredients": "Poivre (QS)|Sel de Guérande (QS)|Noix de Saint-Jacques (500 g)|Beurre (40 g)",
     "instructions": "Faire fondre le beurre dans une poêle, déposer les noix et les dorer légèrement sur chaque côté. Servir immédiatement avec une pincée de poivre et sel de Guérande.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "we",
+    "public": "adultes"
   },
   {
     "id": "p140",
@@ -1845,7 +2107,9 @@
     "ingredients": "Gingembre (2 cm)|Chili (1 c. c.)|Curcuma (1 c. c.)|Sel (QS)|Yaourts (2 pots)|Coriandre (QS)|Huile (2 c. s.)|Poulet (blancs, 500 g)|Ail (2 gousses)|Citron (1, jus)|Citron vert (2, quartiers pour le service)|Salade (QS, pour le service)",
     "instructions": "Mélangez les cubes de poulet avec gingembre, ail, chili, curcuma, sel, yaourt, jus de citron et coriandre, couvrez et laissez mariner au moins 2h. Disposez le poulet dans un plat résistant à la chaleur revêtu d'aluminium, badigeonnez avec de l'huile, et grillez au four 15-20 mn en retournant et badigeonnant 2-3 fois. Servez sur un lit de salade avec des quartiers de citron vert.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "semaine",
+    "public": "tous"
   },
   {
     "id": "p141",
@@ -1859,7 +2123,9 @@
     "ingredients": "pain de mie (4 pains à hot dog)|Relish (4 c. c.)|Knackis (4)|Ketchup (QS)|Moutarde (QS)",
     "instructions": "Faire cuire les saucisses au micro-ondes ou à la casserole avec de l'eau pendant 3 min. Toaster les pains pendant 2 min. Déposer les saucisses dans les pains, ajouter du relish, puis la moutarde et le ketchup à volonté.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "semaine",
+    "public": "kids"
   },
   {
     "id": "p142",
@@ -1873,7 +2139,9 @@
     "ingredients": "Huile (2 c. s.)|Porc (côtes, 4, ~800 g)|Citron (1)|Curry (1 c. s.)|Miel (2 c. s.)",
     "instructions": "Mélanger l'huile, le curry, le miel et le jus du citron. Faire cuire les côtes de porc à la poêle. À mi-cuisson, arroser avec la préparation. Terminer la cuisson en retournant souvent la viande.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "semaine",
+    "public": "tous"
   },
   {
     "id": "p143",
@@ -1887,7 +2155,9 @@
     "ingredients": "Paupiettes de veau (4, ~600 g)|Huile olive (1 c. s.)|Fond de veau (1 c. c. ou 1 tablette, QS)|Ail (2 gousses)|Vin blanc (100 ml)|Eau (100 ml)|Sel (QS)|Poivre (QS)|Moutarde (1 c. c.)|Vinaigre balsamique (1 c. s.)",
     "instructions": "Épluchez et pressez l’ail au-dessus de la cuve du Cookeo. Ajoutez l’huile d’olive et les paupiettes, dorez sur le mode ‘dorer’ pendant 6 min avec préchauffage en remuant constamment. Ajoutez le fond de veau, mouillez avec le vin blanc et l’eau, ajoutez la moutarde, le vinaigre balsamique, salez, poivrez, et cuisez sous pression pendant 19 min. Remuez et maintenez au chaud jusqu’à dégustation.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "tous",
+    "public": "adultes"
   },
   {
     "id": "p144",
@@ -1901,7 +2171,9 @@
     "ingredients": "Sel (QS)|Cuisse de dinde (2 grosses, ~1.2 kg)|Herbes de Provence (1 c. s.)|Ail (4 gousses)|Huile olive (2 c. s.)|Poivre (QS)|Sauce soja (2 c. s.)|Moutarde douce (3 c. s.)",
     "instructions": "Le soir avant, mettre la cuisse dans votre plat rectangulaire ou ovale et inciser la cuisse plusieurs fois en introduisant un bout d’ail (aidez vous du couteau en écartant la fente et pousser avec les doigts). Enduire de moutarde douce partout, parsemer d’herbes, recouvrir d’une feuille d’alu et mettre au frigo jusqu’au lendemain. Le lendemain, sortir du frigo au moins une bonne heure avant la cuisson. Préchauffez votre four à 180°C (chaleur à air pulsé, 200°C four conventionnel je pense). Enduire la marinade de partout (de préférence avec un pinceau culinaire, c’est plus facile), saler à votre goût et versez 10 cl d’eau tout au tour. Mettre au milieu du four pendant 1 heure en arrosant avec le jus très régulièrement (ajoutez de l’eau autour quand nécessaire). Eteindre le four, sortir le plat et recouvrir avec l’alu déjà utilisé pendant 15 min. Coupez la cuisse en tranches, les mettre dans le plat et les retourner pour bien imbiber du jus. Recouvrir à nouveau avec l’alu et remettre dans le four pendant quelques min. Accompagnez de légumes, riz, purée, pommes de terre rissolées ou tagliatelles (salade) d’après votre choix. BON APPETIT !",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "semaine",
+    "public": "tous"
   },
   {
     "id": "p145",
@@ -1915,7 +2187,9 @@
     "ingredients": "Poivre (QS)|Sel (QS)|Thym (1 c. c.)|Oignons (1, surgelés ou frais)|Huile olive (2 c. s.)|Porc (côtes, 4, ~800 g)|Moutarde (3 c. s.)",
     "instructions": "Préchauffer le four à 220°C (thermostat 7-8). Mettre de la moutarde sur les deux faces des côtes de porc. Les saler et les poivrer. Huiler un plat allant au four. Disposer les côtelettes les unes à côté des autres puis les recouvrir légèrement de thym et d'oignons surgelés (On peut très bien utiliser des oignons frais mais ils ont tendance à brûler un peu). Ensuite, faire couler un peu d'huile olive et mettre au four pendant 45 min.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "we",
+    "public": "adultes"
   },
   {
     "id": "p146",
@@ -1929,7 +2203,9 @@
     "ingredients": "Nouilles ramen (300 g)|Bouillon cube (2)|Poulet (cuit, émincé, 300 g)|Œufs (4, mollets)|Légumes (carottes, épinards) (300 g)|Sauce soja (2 c. s.)|Gingembre (2 cm)",
     "instructions": "Cuire les nouilles dans le bouillon. Ajouter la viande cuite, les légumes et un oeuf mollet. Assaisonner avec sauce soja et gingembre. Servir chaud.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "semaine",
+    "public": "tous"
   },
   {
     "id": "p147",
@@ -1943,7 +2219,9 @@
     "ingredients": "Thon (300 g)|avocat (2)|Tomates (300 g)|Riz (cuit, froid, 250 g)|Oignons (1)|Vinaigre (1 c. s.)|Huile olive (3 c. s.)|Herbes (QS)",
     "instructions": "Mélanger le riz froid avec le thon, avocat en dés, tomates et oignon. Arroser de vinaigrette et herbes fraîches. Servir frais.",
     "type_repas": "entree",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "semaine",
+    "public": "tous"
   },
   {
     "id": "p148",
@@ -1957,7 +2235,9 @@
     "ingredients": "Petit salé (porc) (800 g)|Lentilles vertes (300 g)|Carottes (300 g)|Oignons (1)|Ail (2 gousses)|Bouquet garni (1)|Sel, poivre (QS)",
     "instructions": "Cuire le petit salé avec les légumes et le bouquet garni dans de l'eau. Ajouter les lentilles et mijoter 45 minutes. Servir chaud.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "tous",
+    "public": "tous"
   },
   {
     "id": "p149",
@@ -1971,7 +2251,9 @@
     "ingredients": "Poulet (500 g)|Oignons (1)|Carottes (300 g)|Tomates (300 g)|Ail (2 gousses)|Herbes (QS)|Bouillon cube (1)",
     "instructions": "Faire dorer le poulet. Ajouter les légumes et le bouillon. Mijoter à couvert 30-40 minutes. Assaisonner et servir avec des pommes de terre.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "tous",
+    "public": "tous"
   },
   {
     "id": "p150",
@@ -1985,7 +2267,9 @@
     "ingredients": "Boudin noir (600 g)|Pommes (3)|Oignons (1)|Beurre (30 g)|Vinaigre (1 c. s.)|Sel, poivre (QS)",
     "instructions": "Cuire les pommes en tranches dans du beurre avec oignon. Griller le boudin séparément. Mélanger et déglacer avec du vinaigre. Servir chaud.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "tous",
+    "public": "adultes"
   },
   {
     "id": "p151",
@@ -1999,7 +2283,9 @@
     "ingredients": "Pâtes (400 g)|Pesto (4 c. s.)|Tomates cerises (250 g)|Parmesan râpé (60 g)|Huile olive (1 c. s.)|Sel (QS)",
     "instructions": "Faire cuire les pâtes dans l'eau bouillante salée selon les indications du paquet. Couper les tomates cerises en deux. Égoutter les pâtes en réservant un peu d'eau de cuisson. Mélanger les pâtes chaudes avec le pesto et un peu d'eau de cuisson pour détendre la sauce, ajouter les tomates cerises. Parsemer de parmesan râpé avant de servir.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "semaine",
+    "public": "kids"
   },
   {
     "id": "p152",
@@ -2013,7 +2299,9 @@
     "ingredients": "Pâtes (400 g)|Tomates (600 g, fraîches ou pelées en boîte)|Oignons (1)|Ail (2 gousses)|Basilic (QS)|Huile olive (2 c. s.)|Sucre (1 pincée)|Sel, poivre (QS)",
     "instructions": "Faire revenir l'oignon et l'ail émincés dans l'huile d'olive. Ajouter les tomates concassées, une pincée de sucre, saler et poivrer. Laisser mijoter 15 min en écrasant les tomates à la fourchette. Pendant ce temps, cuire les pâtes dans l'eau bouillante salée. Ajouter le basilic ciselé à la sauce puis mélanger avec les pâtes égouttées.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "semaine",
+    "public": "kids"
   },
   {
     "id": "p153",
@@ -2027,7 +2315,9 @@
     "ingredients": "Macaronis (350 g)|Jambon blanc (200 g)|Beurre (40 g)|Farine (40 g)|Lait (500 ml)|Gruyère râpé (150 g)|Muscade (1 pincée)|Sel, poivre (QS)",
     "instructions": "Préchauffer le four à 200°C. Cuire les macaronis al dente. Préparer une béchamel: fondre le beurre, ajouter la farine, puis verser le lait petit à petit en fouettant jusqu'à épaississement. Assaisonner de muscade, sel et poivre. Couper le jambon en dés. Mélanger macaronis, béchamel et jambon avec la moitié du fromage. Verser dans un plat à gratin, parsemer du reste de fromage. Enfourner 15 min jusqu'à ce que le dessus soit doré.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "semaine",
+    "public": "kids"
   },
   {
     "id": "p154",
@@ -2041,7 +2331,9 @@
     "ingredients": "Pâtes (400 g)|Saumon frais ou fumé (300 g)|Crème fraîche (200 ml)|Citron (1)|Aneth ou ciboulette (QS)|Sel, poivre (QS)",
     "instructions": "Cuire les pâtes dans l'eau bouillante salée. Couper le saumon en morceaux. Dans une poêle, faire chauffer la crème avec le zeste et un filet de jus de citron. Ajouter le saumon et laisser cuire 4-5 min à feu doux (ou simplement réchauffer si fumé). Égoutter les pâtes, les mélanger à la sauce, parsemer d'herbes fraîches avant de servir.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "we",
+    "public": "adultes"
   },
   {
     "id": "p155",
@@ -2055,7 +2347,9 @@
     "ingredients": "Pâtes (400 g)|Courge butternut (500 g)|Oignons (1)|Ail (2 gousses)|Beurre (30 g)|Sauge (quelques feuilles)|Parmesan râpé (60 g)|Sel, poivre (QS)",
     "instructions": "Éplucher et couper la courge butternut en petits dés. Faire revenir l'oignon et l'ail dans le beurre, ajouter la courge et un peu d'eau, couvrir et cuire 20 min jusqu'à tendreté en écrasant grossièrement à la fourchette. Ajouter la sauge ciselée. Cuire les pâtes, les mélanger à la préparation de courge, parsemer de parmesan avant de servir.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "semaine",
+    "public": "kids"
   },
   {
     "id": "p156",
@@ -2069,7 +2363,9 @@
     "ingredients": "Coquillettes (350 g)|Jambon blanc (200 g)|Beurre (40 g)|Sel (QS)",
     "instructions": "Cuire les coquillettes dans l'eau bouillante salée selon les indications du paquet. Couper le jambon en petits dés ou lamelles. Égoutter les pâtes, ajouter le beurre et le jambon, mélanger et servir aussitôt.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "semaine",
+    "public": "kids"
   },
   {
     "id": "p157",
@@ -2083,7 +2379,9 @@
     "ingredients": "Escalopes de dinde (4, ~500 g)|Champignons de Paris (250 g)|Crème fraîche (200 ml)|Oignons (1)|Beurre (20 g)|Huile (1 c. s.)|Sel, poivre (QS)|Persil (QS, optionnel)",
     "instructions": "Émincer l'oignon et les champignons. Faire dorer les escalopes de dinde dans le beurre et l'huile 3-4 min de chaque côté, puis réserver. Dans la même poêle, faire revenir l'oignon puis les champignons jusqu'à évaporation de l'eau de végétation. Ajouter la crème fraîche, saler, poivrer et laisser réduire 2-3 min. Remettre les escalopes dans la sauce, réchauffer 2 min. Parsemer de persil et servir.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "semaine",
+    "public": "tous"
   },
   {
     "id": "p158",
@@ -2097,7 +2395,9 @@
     "ingredients": "Saucisses de Toulouse (8, ~600 g)|Lentilles cuites (400 g, ou purée Picard surgelée)|Oignons (1)|Huile (1 c. s.)|Thym (1 pincée)|Sel, poivre (QS)",
     "instructions": "Faire cuire les saucisses de Toulouse à la poêle avec un filet d'huile, environ 15 min en les retournant régulièrement jusqu'à ce qu'elles soient bien dorées. Émincer l'oignon et le faire fondre dans la même poêle. Réchauffer les lentilles cuites avec l'oignon et le thym, ou faire cuire la purée Picard surgelée selon les indications du paquet. Servir les saucisses accompagnées des lentilles ou de la purée.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "tous",
+    "public": "adultes"
   },
   {
     "id": "p159",
@@ -2111,7 +2411,9 @@
     "ingredients": "Lait de coco (400 ml)|Légumes variés, courgettes/carottes/poivrons/brocolis (600 g)|Oignons (1)|Ail (2 gousses)|Curry (1 c. s.)|Gingembre (1 cm)|Huile (1 c. s.)|Riz (300 g)|Sel (QS)",
     "instructions": "Couper les légumes en morceaux. Faire revenir l'oignon, l'ail et le gingembre dans l'huile, ajouter le curry et mélanger 1 min. Ajouter les légumes, faire revenir 2-3 min puis verser le lait de coco. Laisser mijoter 15-20 min jusqu'à ce que les légumes soient tendres. Servir avec du riz cuit à part.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "semaine",
+    "public": "tous"
   },
   {
     "id": "p160",
@@ -2125,7 +2427,9 @@
     "ingredients": "Riz (300 g, cuit et refroidi)|Poulet ou porc cuit (200 g, en dés)|Œufs (2)|Petits pois (150 g)|Jambon blanc (100 g, en dés)|Sauce soja (2 c. s.)|Huile (2 c. s.)|Oignons nouveaux (2)",
     "instructions": "Battre les œufs et les cuire en fine omelette, puis les couper en lamelles. Faire chauffer l'huile dans un wok ou une grande poêle, faire revenir le riz cuit refroidi 2-3 min. Ajouter la viande, le jambon et les petits pois, bien mélanger. Ajouter les lamelles d'omelette et la sauce soja. Réchauffer 2-3 min en remuant, parsemer d'oignons nouveaux ciselés avant de servir.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "semaine",
+    "public": "kids"
   },
   {
     "id": "p161",
@@ -2139,7 +2443,9 @@
     "ingredients": "Bœuf haché (500 g)|Chapelure (40 g)|Œuf (1)|Ail (2 gousses)|Persil (QS)|Tomates (500 g, fraîches ou pelées en boîte)|Oignons (1)|Huile olive (2 c. s.)|Sel, poivre (QS)|Pâtes ou riz (350 g, pour l'accompagnement)",
     "instructions": "Mélanger la viande hachée, la chapelure, l'œuf, l'ail écrasé et le persil ciselé, saler et poivrer. Former des boulettes. Les faire dorer dans l'huile d'olive sur toutes les faces, puis réserver. Dans la même poêle, faire revenir l'oignon émincé, ajouter les tomates concassées, saler et poivrer. Remettre les boulettes dans la sauce et laisser mijoter 15-20 min à couvert. Servir avec des pâtes ou du riz.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "semaine",
+    "public": "kids"
   },
   {
     "id": "p162",
@@ -2153,7 +2459,9 @@
     "ingredients": "Escalopes de poulet (4, ~500 g)|Jambon blanc (4 tranches)|Emmental ou gruyère (4 tranches)|Farine (60 g)|Œufs (2)|Chapelure (100 g)|Huile (pour cuisson à la poêle)|Sel, poivre (QS)",
     "instructions": "Ouvrir chaque escalope en portefeuille sans la détacher complètement. Garnir d'une tranche de jambon et d'une tranche de fromage, refermer et presser légèrement les bords. Passer chaque escalope dans la farine, puis l'œuf battu, puis la chapelure. Faire cuire à la poêle dans un peu d'huile 5-6 min de chaque côté à feu moyen jusqu'à ce que le poulet soit cuit et bien doré (ou cuire au four 20 min à 200°C).",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "semaine",
+    "public": "kids"
   },
   {
     "id": "p163",
@@ -2167,7 +2475,9 @@
     "ingredients": "Saumon frais (500 g, qualité tartare)|Avocat (2)|Citron vert (1)|Aneth (QS)|Sauce soja (2 c. s.)|Huile de sésame (1 c. s.)|Graines de sésame (1 c. s.)|Sel, poivre (QS)",
     "instructions": "Couper le saumon en petits dés réguliers. Couper l'avocat en dés et l'arroser d'un peu de jus de citron vert pour éviter qu'il noircisse. Mélanger saumon, avocat, aneth ciselé, sauce soja, huile de sésame et le reste du jus de citron vert. Saler, poivrer, parsemer de graines de sésame. Réserver au frais 15 min avant de servir, éventuellement dressé dans des cercles pour la présentation.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "we",
+    "public": "adultes"
   },
   {
     "id": "p164",
@@ -2181,7 +2491,9 @@
     "ingredients": "Filet de bœuf (500 g, tranché finement)|Huile olive (4 c. s.)|Parmesan (80 g, en copeaux)|Roquette (80 g)|Pignons de pin (30 g)|Citron (1/2)|Sel, poivre (QS)",
     "instructions": "Trancher le filet de bœuf le plus finement possible (le passer 30 min au congélateur facilite la découpe). Disposer les tranches sur des assiettes en une seule couche. Arroser d'huile d'olive et d'un filet de jus de citron, saler et poivrer. Parsemer de copeaux de parmesan, de roquette et de pignons de pin légèrement torréfiés à sec. Servir immédiatement bien frais.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "we",
+    "public": "adultes"
   },
   {
     "id": "p165",
@@ -2195,7 +2507,9 @@
     "ingredients": "Thon (pavé, qualité tartare, 500 g)|Sauce soja (3 c. s.)|Gingembre (2 cm, râpé)|Huile de sésame (1 c. s.)|Graines de sésame (2 c. s.)|Huile (1 c. s., pour saisir)|Citron vert (1)",
     "instructions": "Rouler le pavé de thon dans les graines de sésame. Saisir 30 secondes de chaque face dans une poêle très chaude avec un peu d'huile, le centre doit rester cru. Réserver au frais 10 min puis trancher finement. Mélanger la sauce soja, le gingembre râpé, l'huile de sésame et un filet de jus de citron vert pour la sauce d'accompagnement. Servir les tranches de thon nappées de sauce.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "we",
+    "public": "adultes"
   },
   {
     "id": "p166",
@@ -2209,7 +2523,9 @@
     "ingredients": "Rôti de veau (600 g, cuit et refroidi)|Thon (au naturel, 150 g)|Câpres (2 c. s.)|Mayonnaise (150 g)|Citron (1 c. s. de jus)|Anchois (2 filets, optionnel)|Sel, poivre (QS)",
     "instructions": "Faire cuire le rôti de veau la veille (poché ou rôti), le laisser refroidir puis le trancher très finement. Mixer le thon égoutté, la moitié des câpres, la mayonnaise, le jus de citron et les anchois jusqu'à obtenir une sauce lisse. Napper les tranches de veau froid de cette sauce, parsemer du reste de câpres. Réserver au frais avant de servir.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "we",
+    "public": "adultes"
   },
   {
     "id": "p167",
@@ -2223,7 +2539,9 @@
     "ingredients": "Magret de canard (2, ~700 g)|Miel (3 c. s.)|Vinaigre balsamique (3 c. s.)|Sel, poivre (QS)",
     "instructions": "Quadriller le gras du magret au couteau. Saisir côté peau à froid dans une poêle, cuire 6-8 min à feu moyen jusqu'à ce que le gras soit doré et fondu, puis 3-4 min côté chair. Réserver au chaud sous papier alu. Dégraisser la poêle, déglacer avec le vinaigre balsamique et le miel, laisser réduire 2-3 min jusqu'à consistance sirupeuse. Trancher le magret et napper de sauce.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "we",
+    "public": "adultes"
   },
   {
     "id": "p168",
@@ -2237,7 +2555,9 @@
     "ingredients": "Andouillettes (4)|Moutarde de Dijon (3 c. s.)|Crème fraîche (150 ml)|Echalotes (2)|Vin blanc (100 ml)|Beurre (20 g)|Sel, poivre (QS)",
     "instructions": "Faire griller les andouillettes à la poêle ou au barbecue 15-20 min en les retournant régulièrement. Pendant ce temps, faire fondre les échalotes ciselées dans le beurre, déglacer au vin blanc et laisser réduire de moitié. Ajouter la crème fraîche et la moutarde, laisser épaissir légèrement à feu doux sans bouillir. Servir les andouillettes nappées de sauce, avec des frites ou une purée maison.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "tous",
+    "public": "adultes"
   },
   {
     "id": "p169",
@@ -2251,7 +2571,9 @@
     "ingredients": "Farine de blé T65 (300 g)|Farine de riz (50 g)|Fécule de maïs (30 g, optionnel)|Eau froide (280 ml)|Levure fraîche (3 g, ou levure sèche 1 g)|Huile olive (15 g)|Sel (8 g)",
     "instructions": "Mélanger les farines et la fécule. Diluer la levure dans l'eau froide, puis verser sur les farines et pétrir 5 min pour obtenir une pâte très hydratée et collante. Ajouter le sel puis l'huile d'olive, pétrir encore 5 min. Couvrir et laisser reposer 2h à température ambiante, puis placer au réfrigérateur 24 à 48h (plus la pousse est longue, plus la pinsa sera digeste et alvéolée). Sortir la pâte 1h avant utilisation, la diviser en 2-3 pâtons et les étaler à la main en forme ovale sans trop les dégazer pour garder les bulles d'air. Temps de préparation actif court, le reste est du repos.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "we",
+    "public": "tous"
   },
   {
     "id": "p170",
@@ -2265,7 +2587,9 @@
     "ingredients": "Pâtes à pinsa (2, du commerce ou maison)|Stracciatella (250 g)|Sauge fraîche (1 bouquet)|Huile olive (3 c. s.)|Ail (1 gousse)|Fleur de sel, poivre (QS)",
     "instructions": "Préchauffer le four à 250°C (ou température maximale). Étaler les pâtes à pinsa sur une plaque. Frotter légèrement d'ail, arroser d'huile d'olive et parsemer de quelques feuilles de sauge ciselées. Cuire à blanc 10-12 min jusqu'à ce que les bords soient bien dorés et croustillants. À la sortie du four, répartir la stracciatella sur les pinsas encore chaudes, parsemer de sauge fraîche, d'un filet d'huile d'olive et de fleur de sel.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "tous",
+    "public": "tous"
   },
   {
     "id": "p171",
@@ -2279,7 +2603,9 @@
     "ingredients": "Pâtes à pinsa (2, du commerce ou maison)|Burrata (2, ~250 g)|Artichauts marinés à l'huile (200 g)|Jambon cru (6 tranches)|Tomates cerises (150 g)|Huile olive (2 c. s.)|Basilic (QS)|Poivre (QS)",
     "instructions": "Préchauffer le four à 250°C. Étaler les pâtes à pinsa sur une plaque, arroser d'un peu d'huile d'olive. Répartir les artichauts marinés égouttés et les tomates cerises coupées en deux. Cuire à blanc 10-12 min jusqu'à ce que la pâte soit dorée et croustillante. À la sortie du four, déposer le jambon cru et la burrata déchirée en morceaux sur les pinsas chaudes. Parsemer de basilic frais et d'un tour de moulin à poivre avant de servir.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "tous",
+    "public": "kids"
   },
   {
     "id": "p172",
@@ -2293,7 +2619,9 @@
     "ingredients": "Pâtes à pinsa (2, du commerce ou maison)|Mozzarella ou burrata (200 g)|Jambon de Parme ou coppa (8 tranches)|Roquette (80 g)|Parmesan (60 g, copeaux)|Huile olive (2 c. s.)|Tomates (200 g, sauce, optionnel)",
     "instructions": "Préchauffer le four à 250°C. Étaler les pâtes à pinsa sur une plaque, napper d'un peu de sauce tomate si utilisée et ajouter la mozzarella (garder la burrata pour après cuisson si utilisée à la place). Cuire à blanc 10-12 min jusqu'à ce que la pâte soit dorée et croustillante. À la sortie du four, déposer les tranches de jambon de Parme (ou coppa), la roquette et les copeaux de parmesan sur la pinsa encore chaude (le jambon cru ne doit pas cuire, seulement se réchauffer au contact). Arroser d'un filet d'huile d'olive avant de servir.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "tous",
+    "public": "kids"
   },
   {
     "id": "p173",
@@ -2307,7 +2635,9 @@
     "ingredients": "Veau (800 g, épaule ou tendron, en cubes de 3 cm)|Champignons de Paris (90 g)|Carottes (1-2)|Concentré de tomate (35 g)|Vin blanc sec (20 cl)|Échalotes (3)|Ail (2 gousses)|Bouquet garni (1)|Eau (20 cl)|Farine (1 c. à s.)|Beurre (50 g)|Sel, poivre (QS)",
     "instructions": "Couper la viande de veau en cubes de 3 cm. Couper les carottes en rondelles, émincer finement les échalotes et l'ail. Couper les champignons en deux. Dans une cocotte à fond épais, faire dorer les morceaux de veau dans le beurre. Ajouter les carottes, l'ail et les échalotes, laisser cuire jusqu'à ce qu'ils deviennent translucides. Saupoudrer de farine et laisser blondir 1-2 min en remuant. Ajouter le concentré de tomate, l'eau, le vin blanc et le bouquet garni. Saler, poivrer, couvrir et laisser mijoter environ 1h30 à feu doux. Ajouter les champignons 15 min avant la fin de cuisson. Servir avec des pâtes, du riz ou des pommes vapeur.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "we",
+    "public": "adultes"
   },
   {
     "id": "p174",
@@ -2321,7 +2651,9 @@
     "ingredients": "Blanc de poulet (500 g, en morceaux)|Poivrons jaunes (2)|Olives vertes farcies au piment (180 g)|Citron jaune (1)|Miel liquide (1 c. à c.)|Menthe ciselée (1 c. à s.)|Huile olive (3 c. à s.)|Sel, poivre (QS)|Laitue (1)|Pastèque (1/3, en dés)|Feta ferme émiettée (180 g)|Vinaigre (1 c. à c.)|Huile olive (2 c. à s., pour la salade)",
     "instructions": "Épépiner les poivrons et les couper en petits morceaux, les mélanger avec les olives vertes et un peu d'huile d'olive, laisser reposer 15 min. Prélever le zeste du citron puis presser le jus. Dans un bol, mélanger le zeste, le jus de citron, le miel, le reste d'huile d'olive, la menthe ciselée, le sel et le poivre. Ajouter les morceaux de poulet et bien enrober. Enfiler le poulet sur des piques à brochette en alternant avec les morceaux de poivron et les olives. Faire cuire les brochettes à feu moyen au barbecue ou à la poêle grill, en arrosant régulièrement de marinade, jusqu'à ce que le poulet soit bien cuit. Pendant ce temps, disposer les feuilles de laitue sur un plat, répartir la pastèque puis la feta. Préparer une vinaigrette avec l'huile d'olive, le vinaigre, le sel et le poivre, en arroser la salade. Ajouter les brochettes chaudes sur la salade et parsemer de menthe ciselée avant de servir.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "tous",
+    "public": "tous"
   },
   {
     "id": "p175",
@@ -2335,6 +2667,8 @@
     "ingredients": "Veau haché (300 g)|Courgette (1)|Farine (2 c. à s.)|Huile olive (1 c. à s.)|Basilic (1 pincée, frais ou séché)|Oignons (1)|Œuf (1)|Sel, poivre (QS)|Tomates et oignons en rondelles (QS, pour accompagner, optionnel)",
     "instructions": "Laver la courgette et la râper grossièrement. Dans un bol, mélanger la viande de veau hachée, la courgette râpée, l'œuf battu et l'oignon finement coupé. Ajouter le basilic, saler et poivrer. Façonner des boulettes avec la préparation et les rouler dans la farine. Les enfiler sur des piques à brochette, en alternant éventuellement avec des rondelles de tomate et d'oignon, puis faire cuire au barbecue ou à la poêle avec un filet d'huile jusqu'à ce qu'elles soient bien dorées. Égoutter sur du papier absorbant et servir aussitôt.",
     "type_repas": "plat",
-    "categorie_jour": ""
+    "categorie_jour": "",
+    "moment": "tous",
+    "public": "adultes"
   }
 ]


### PR DESCRIPTION
## Objectif

Adapter le générateur de planning au rythme réel de la famille (enfants à la cantine en semaine, week-end plus gourmand) et donner aux recettes de vraies étiquettes exploitables.

## Étiquettes recettes (`recipes.json`)

Deux nouveaux champs sur **les 167 recettes** :
- `moment` : `semaine` · `we` · `tous` — quand servir la recette
- `public` : `kids` · `adultes` · `tous` — pour qui

Classées automatiquement (nom, protéine, temps, budget) puis validées. Les champs hérités `kidsFriendly` / `categorie_jour` restent pour compatibilité mais ne sont plus la source de vérité.

## Générateur de planning (`eat.html`)

Réécrit autour de la constante `PLANNING_SLOTS` — **9 repas** :
- **Semaine** : dîners Lun→Ven + déjeuner du mercredi. Plats `moment ∈ {semaine, tous}` **et** `public ∈ {kids, tous}` ; déjeuner → plats rapides privilégiés.
- **Week-end** : samedi dîner + dimanche déjeuner & dîner. Plats `moment ∈ {we, tous}`, plus qualitatifs (budget moyen/élevé ou temps > 45 min).
- Les **midis d'école** (Lun/Mar/Jeu/Ven) sont exclus.
- Variété : déduplication des recettes + plafond de 2 par protéine.

Badges des cartes mis à jour (👶 Kids / 🍷 Adultes / 🗓️ WE) et rendu du planning adapté aux créneaux réellement présents.

## Vérification

15 générations pilotées dans Chromium : toutes conformes (9 repas, bons créneaux, pools respectés, aucun midi d'école, 0 doublon, 0 erreur JS). Export du planning vers la liste de courses fonctionnel.

## Doc

`CLAUDE.md` : modèle de données (moment/public) et logique de planning documentés.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017EeGcqWUiDk6iWYMKhXWFH)_