### PR TITLE
Planning : ne proposer que des recettes de saison

### DIFF
--- a/eat.html
+++ b/eat.html
@@ -569,22 +569,49 @@
       // ============================================
       // GÉNÉRATEUR DE PLANNING INTELLIGENT
       // ============================================
+      // Saison courante (hémisphère nord) d'après le mois
+      function currentSeason(date = new Date()) {
+        const m = date.getMonth(); // 0 = janvier
+        if (m >= 2 && m <= 4) return "printemps";
+        if (m >= 5 && m <= 7) return "ete";
+        if (m >= 8 && m <= 10) return "automne";
+        return "hiver";
+      }
+      // Une recette est de saison si "toute"/"toutes"/vide, ou si elle liste
+      // la saison courante. Tolère les accents (été → ete) et le séparateur « | ».
+      function matchesSeason(recipe, season) {
+        const raw = (recipe.saisons || "")
+          .toLowerCase()
+          .normalize("NFD")
+          .replace(/[\u0300-\u036f]/g, "");
+        if (!raw.trim()) return true;
+        const set = raw.split("|").map((s) => s.trim());
+        if (set.includes("toute") || set.includes("toutes")) return true;
+        return set.includes(season);
+      }
+
       function generateWeeklyPlanning() {
         // Réinitialiser
         weeklyPlanning = {};
 
+        const season = currentSeason();
         const plats = allRecipes.filter((r) => r.type_repas === "plat");
+        const seasonal = plats.filter((r) => matchesSeason(r, season));
 
-        // Pool SEMAINE : plats semaine/tous, plutôt kids/tous
-        const semainePool = plats.filter(
-          (r) =>
-            (r.moment === "semaine" || r.moment === "tous") &&
-            (r.public === "kids" || r.public === "tous")
-        );
-        // Pool WEEK-END : plats we/tous, tous publics (adultes bienvenus)
-        const wePool = plats.filter(
-          (r) => r.moment === "we" || r.moment === "tous"
-        );
+        const mkSemaine = (src) =>
+          src.filter(
+            (r) =>
+              (r.moment === "semaine" || r.moment === "tous") &&
+              (r.public === "kids" || r.public === "tous")
+          );
+        const mkWe = (src) =>
+          src.filter((r) => r.moment === "we" || r.moment === "tous");
+
+        // Pools de saison, avec repli sur toute l'année si trop peu de choix
+        let semainePool = mkSemaine(seasonal);
+        let wePool = mkWe(seasonal);
+        if (semainePool.length < 6) semainePool = mkSemaine(plats);
+        if (wePool.length < 3) wePool = mkWe(plats);
 
         if (semainePool.length < 6 || wePool.length < 3) {
           showToast("Pas assez de recettes étiquetées pour générer le planning");


### PR DESCRIPTION
## Problème

Le générateur de planning ignorait le champ `saisons` — d'où une **tartiflette proposée en plein juillet**.

## Correctif (`eat.html`)

- `currentSeason()` : déduit la saison (hémisphère nord) du mois courant.
- `matchesSeason(recipe, saison)` : une recette est retenue si son champ `saisons` vaut `toute`/`toutes`/vide **ou** contient la saison courante. Tolérant aux accents (`été` → `ete`), au `toutes` et au séparateur `|` — le champ étant hétérogène dans le catalogue.
- Les pools **semaine** et **we** sont filtrés sur la saison, avec **repli** sur toute l'année si le choix devient trop restreint (jamais le cas en pratique : ≥ 51 plats/pool à chaque saison).

## Vérification

Chromium (horloge = été) : tests unitaires OK (tartiflette exclue en été, incluse en hiver ; `toute`/`toutes`/accents/combos gérés) et **135 plats générés sur 15 plannings → 0 hors saison**, aucune erreur JS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017EeGcqWUiDk6iWYMKhXWFH)_