### PR TITLE
Recettes : passe d'affinage des saisons (conservatrice)

### DIFF
--- a/recipes.json
+++ b/recipes.json
@@ -18,7 +18,7 @@
   {
     "id": "p2",
     "nom": "Tian de légumes au four",
-    "saisons": "ete|automne",
+    "saisons": "printemps|ete",
     "diets": "equilibre|vegetarien|vegetalien|sans gluten",
     "kidsFriendly": "Oui",
     "temps": "50",
@@ -418,7 +418,7 @@
   {
     "id": "p27",
     "nom": "Saumon grillé avec riz basmati",
-    "saisons": "toute",
+    "saisons": "printemps|ete",
     "diets": "equilibre|poisson",
     "kidsFriendly": "Oui",
     "temps": "25",
@@ -482,7 +482,7 @@
   {
     "id": "p31",
     "nom": "Falafels maison avec salade",
-    "saisons": "toute",
+    "saisons": "printemps|ete",
     "diets": "equilibre|vegetarien|vegetalien",
     "kidsFriendly": "Oui",
     "temps": "30",
@@ -882,7 +882,7 @@
   {
     "id": "p56",
     "nom": "Thon mi-cuit avec avocat",
-    "saisons": "toute",
+    "saisons": "printemps|ete",
     "diets": "equilibre|poisson",
     "kidsFriendly": "Oui",
     "temps": "15",
@@ -994,7 +994,7 @@
   {
     "id": "p63",
     "nom": "Salade de lentilles et betteraves",
-    "saisons": "toute",
+    "saisons": "printemps|ete",
     "diets": "equilibre|vegetarien|vegetalien|sans gluten",
     "kidsFriendly": "Oui",
     "temps": "15",
@@ -1346,7 +1346,7 @@
   {
     "id": "p85",
     "nom": "Ratatouille et poulet",
-    "saisons": "été|automne",
+    "saisons": "printemps|ete",
     "diets": "equilibre|sans gluten",
     "kidsFriendly": "Oui",
     "temps": "45",
@@ -1714,7 +1714,7 @@
   {
     "id": "p116",
     "nom": "Œufs brouillés à la grecque",
-    "saisons": "",
+    "saisons": "printemps|ete",
     "diets": "equilibre|rapide",
     "kidsFriendly": "Oui",
     "temps": "15",
@@ -1874,7 +1874,7 @@
   {
     "id": "p126",
     "nom": "Steak tartare",
-    "saisons": "toutes",
+    "saisons": "printemps|ete",
     "diets": "facile",
     "kidsFriendly": "Oui",
     "temps": "20",
@@ -1906,7 +1906,7 @@
   {
     "id": "p128",
     "nom": "Crevettes à l'ail",
-    "saisons": "toutes",
+    "saisons": "printemps|ete",
     "diets": "facile|rapide",
     "kidsFriendly": "Non",
     "temps": "20",
@@ -2242,7 +2242,7 @@
   {
     "id": "p149",
     "nom": "Mijoté de poulet",
-    "saisons": "toute",
+    "saisons": "automne|hiver",
     "diets": "equilibre|viande|sans gluten",
     "kidsFriendly": "Oui",
     "temps": "45",
@@ -2466,7 +2466,7 @@
   {
     "id": "p163",
     "nom": "Tartare de saumon",
-    "saisons": "toute",
+    "saisons": "printemps|ete",
     "diets": "bistronomie|poisson",
     "kidsFriendly": "Oui",
     "temps": "20",
@@ -2482,7 +2482,7 @@
   {
     "id": "p164",
     "nom": "Carpaccio de bœuf",
-    "saisons": "toute",
+    "saisons": "printemps|ete",
     "diets": "bistronomie|viande",
     "kidsFriendly": "Non",
     "temps": "20",
@@ -2498,7 +2498,7 @@
   {
     "id": "p165",
     "nom": "Tataki de thon",
-    "saisons": "toute",
+    "saisons": "printemps|ete",
     "diets": "bistronomie|poisson",
     "kidsFriendly": "Non",
     "temps": "20",


### PR DESCRIPTION
## Objectif

Affiner le champ `saisons` du catalogue pour éviter les incongruités (plat d'hiver en plein été), sans dénaturer un catalogue volontairement très « toute saison ».

## Constat

Le catalogue était déjà correctement saisonné dans l'ensemble — la tartiflette était **déjà** taguée `hiver`. L'incident « tartiflette en juillet » venait du **générateur** qui ignorait la saison (corrigé en #12), pas des données.

## Passe (conservatrice) — 13 recettes reséries

Seulement là où le signal est net :
- **→ automne/hiver** : Mijoté de poulet.
- **→ printemps/été** : Tian de légumes, Ratatouille et poulet, Salade de lentilles & betteraves, Falafels + salade, Œufs brouillés à la grecque, et les plats crus/grillés de la mer — Steak tartare, Tartare de saumon, Carpaccio de bœuf, Tataki de thon, Thon mi-cuit, Saumon grillé, Crevettes à l'ail.

Laissés en `toute` volontairement : pâtes, pizza, poulets, currys, ramen, rôtis, couscous, tajine… (mangés toute l'année). L'andouillette, un temps captée par le mot « grillée », a été remise en `toute`.

## Sûreté

Correspondance par mot entier (évite le piège `courge` ⊂ `courgette`). Repli du générateur sur toute l'année si un pool devenait trop maigre — jamais le cas. Vérifié dans Chromium : 167 recettes chargées, 90 plats sur 10 plannings → 0 hors saison, aucune erreur JS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017EeGcqWUiDk6iWYMKhXWFH)_