### PR TITLE
UI : léger renfort du contraste des boutons secondaires

### DIFF
--- a/css/eat.css
+++ b/css/eat.css
@@ -180,8 +180,8 @@ h1 {
   background: rgba(255, 255, 255, 0.9);
   backdrop-filter: blur(8px);
   color: var(--text-primary);
-  border: 2px solid rgba(0, 0, 0, 0.06);
-  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.04);
+  border: 2px solid rgba(15, 23, 42, 0.16);
+  box-shadow: 0 2px 6px rgba(15, 23, 42, 0.08);
 }
 
 .btn-secondary:hover {


### PR DESCRIPTION
## Changement (`css/eat.css`)

Les boutons blancs `.btn-secondary` (Réinitialiser, Nouvelle tentative, Régénérer le planning, Filtres) avaient une bordure quasi invisible (`rgba(0,0,0,0.06)`). Bordure remontée à `rgba(15,23,42,0.16)` et ombre légèrement renforcée pour mieux les détacher du fond clair — ajustement volontairement subtil.

Capture vérifiée : bordure nette mais discrète, sans effet dur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017EeGcqWUiDk6iWYMKhXWFH)_