### PR TITLE
UI : léger renfort du contraste du champ de recherche

### DIFF
--- a/css/eat.css
+++ b/css/eat.css
@@ -101,7 +101,7 @@ h1 {
 .filter-group input,
 .filter-group select {
   padding: 12px 16px;
-  border: 2px solid rgba(59, 130, 246, 0.15);
+  border: 2px solid rgba(59, 130, 246, 0.3);
   border-radius: var(--radius-lg);
   font-size: 14px;
   font-family: inherit;
@@ -110,7 +110,7 @@ h1 {
   color: var(--text-primary);
   transition: all var(--transition-base);
   box-shadow:
-    0 2px 6px rgba(0, 0, 0, 0.04),
+    0 2px 6px rgba(15, 23, 42, 0.08),
     inset 0 1px 2px rgba(255, 255, 255, 0.5);
 }
 


### PR DESCRIPTION
## Changement (`css/eat.css`)

Même esprit que le renfort des boutons secondaires : la bordure du champ « Nom du plat… » (et des selects de filtres, via `.filter-group input/select`) passe de `rgba(59,130,246,0.15)` à `rgba(59,130,246,0.3)`, avec une ombre légèrement renforcée. Reste en bleu doux, cohérent avec le bouton Filtres adjacent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017EeGcqWUiDk6iWYMKhXWFH)_