### PR TITLE
Thème : tokenisation de l'accent bleu (périmètre eat)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,6 +153,26 @@ backend qui se remet en pause.
   (variables CSS `--gradient-primary`, `--radius-*`, police Inter, emojis dans
   l'UI, commentaires FR).
 
+## Thème & couleurs (re-thémage)
+
+Les couleurs sont centralisées en **variables CSS** dans `css/common.css` (`:root`).
+Pour changer l'apparence, éditer ces variables — **pas** les valeurs dans les
+pages.
+
+- **Accent bleu** (couleur d'action : boutons, liens, focus, tags, cartes) :
+  `--accent` et `--accent-strong` pilotent l'essentiel ; les fonds clairs
+  (`--accent-bg`, `--accent-bg-soft`, `--accent-bg-2…5`) et les bordures/ombres
+  translucides en découlent. Les variantes translucides utilisent la *relative
+  color syntax* `rgb(from var(--accent-strong) r g b / α)`, donc elles suivent
+  automatiquement le changement de teinte (Safari 16.4+ / navigateurs récents).
+- **Marque violette** : `--brand-primary` / `--brand-secondary` / `--gradient-primary`.
+- **Sémantiques** : `--success`, `--warning`, `--error`, `--info`.
+- **Statut de la tokenisation** : périmètre **eat** (`eat.html` + `css/eat.css`)
+  entièrement branché sur ces variables. `courses.html`/`css/courses.css` et
+  `index.html` contiennent encore des couleurs en dur (passe à faire au même
+  modèle). Le violet des boutons `.btn-accent` (`#8b5cf6`/`#6366f1`) n'est pas
+  encore tokenisé.
+
 ## Conventions
 
 - Tout en **français** (UI, commentaires, noms de variables métier).

--- a/css/common.css
+++ b/css/common.css
@@ -33,7 +33,21 @@
   --brand-accent: #4facfe;
   --brand-light: #e9d5ff;
   --brand-lighter: #f3e8ff;
-  
+
+  /* Accent bleu — la couleur d'ACTION de l'app (boutons, liens, focus, tags).
+     👉 Pour re-thémer tout le bleu, changez surtout --accent et --accent-strong ;
+        les bordures/ombres translucides bleues en découlent automatiquement. */
+  --accent: #0ea5e9;          /* accent principal */
+  --accent-strong: #3b82f6;   /* variante soutenue / dégradés */
+  --accent-ink: #1e40af;      /* texte bleu foncé sur fond clair */
+  --accent-bg: #e0f2fe;       /* fond clair 1 */
+  --accent-bg-soft: #f0f9ff;  /* fond très clair */
+  --accent-bg-2: #dbeafe;     /* fond clair 2 */
+  --accent-bg-3: #bfdbfe;     /* fond clair 3 */
+  --accent-bg-4: #bae6fd;     /* fond clair 4 */
+  --accent-bg-5: #eff6ff;     /* fond clair 5 */
+  --gradient-blue: linear-gradient(135deg, #0ea5e9 0%, #3b82f6 100%);
+
   /* États */
   --success: #10b981;
   --warning: #f59e0b;

--- a/css/eat.css
+++ b/css/eat.css
@@ -6,10 +6,10 @@ body {
   margin: 0;
   background: linear-gradient(
     165deg,
-    #dbeafe 0%,
-    #eff6ff 30%,
+    var(--accent-bg-2) 0%,
+    var(--accent-bg-5) 30%,
     #ffffff 60%,
-    #f0f9ff 100%
+    var(--accent-bg-soft) 100%
   );
   background-attachment: fixed;
   color: var(--text-primary);
@@ -47,7 +47,7 @@ h1 {
   font-size: 32px;
   font-weight: var(--font-weight-extrabold);
   margin: 0 0 12px;
-  background: linear-gradient(135deg, #0ea5e9 0%, #3b82f6 100%);
+  background: linear-gradient(135deg, var(--accent) 0%, var(--accent-strong) 100%);
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
   background-clip: text;
@@ -101,7 +101,7 @@ h1 {
 .filter-group input,
 .filter-group select {
   padding: 12px 16px;
-  border: 2px solid rgba(59, 130, 246, 0.3);
+  border: 2px solid rgb(from var(--accent-strong) r g b / 0.3);
   border-radius: var(--radius-lg);
   font-size: 14px;
   font-family: inherit;
@@ -117,11 +117,11 @@ h1 {
 .filter-group input:focus,
 .filter-group select:focus {
   outline: none;
-  border-color: #3b82f6;
+  border-color: var(--accent-strong);
   background: white;
   box-shadow:
-    0 0 0 4px rgba(59, 130, 246, 0.1),
-    0 4px 12px rgba(59, 130, 246, 0.15);
+    0 0 0 4px rgb(from var(--accent-strong) r g b / 0.1),
+    0 4px 12px rgb(from var(--accent-strong) r g b / 0.15);
   transform: translateY(-1px);
 }
 
@@ -142,11 +142,11 @@ h1 {
 }
 
 .btn-primary {
-  background: linear-gradient(135deg, #0ea5e9 0%, #3b82f6 100%);
+  background: linear-gradient(135deg, var(--accent) 0%, var(--accent-strong) 100%);
   color: white;
   box-shadow:
-    0 4px 12px rgba(59, 130, 246, 0.25),
-    0 2px 6px rgba(14, 165, 233, 0.15);
+    0 4px 12px rgb(from var(--accent-strong) r g b / 0.25),
+    0 2px 6px rgb(from var(--accent) r g b / 0.15);
   position: relative;
   overflow: hidden;
 }
@@ -155,7 +155,7 @@ h1 {
   content: '';
   position: absolute;
   inset: 0;
-  background: linear-gradient(135deg, #3b82f6 0%, #0ea5e9 100%);
+  background: linear-gradient(135deg, var(--accent-strong) 0%, var(--accent) 100%);
   opacity: 0;
   transition: opacity var(--transition-base);
 }
@@ -167,8 +167,8 @@ h1 {
 .btn-primary:hover {
   transform: translateY(-2px);
   box-shadow:
-    0 6px 20px rgba(59, 130, 246, 0.35),
-    0 4px 10px rgba(14, 165, 233, 0.25);
+    0 6px 20px rgb(from var(--accent-strong) r g b / 0.35),
+    0 4px 10px rgb(from var(--accent) r g b / 0.25);
 }
 
 .btn-primary > * {
@@ -186,9 +186,9 @@ h1 {
 
 .btn-secondary:hover {
   background: white;
-  border-color: rgba(59, 130, 246, 0.2);
+  border-color: rgb(from var(--accent-strong) r g b / 0.2);
   transform: translateY(-1px);
-  box-shadow: 0 4px 12px rgba(59, 130, 246, 0.1);
+  box-shadow: 0 4px 12px rgb(from var(--accent-strong) r g b / 0.1);
 }
 
 .btn-accent {
@@ -236,8 +236,8 @@ h1 {
 }
 
 .recipe-card {
-  background: linear-gradient(135deg, #f0f9ff 0%, #e0f2fe 100%);
-  border: 1px solid rgba(59, 130, 246, 0.1);
+  background: linear-gradient(135deg, var(--accent-bg-soft) 0%, var(--accent-bg) 100%);
+  border: 1px solid rgb(from var(--accent-strong) r g b / 0.1);
   border-radius: var(--radius-xl);
   padding: 20px;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.04);
@@ -247,11 +247,11 @@ h1 {
 }
 
 .recipe-card:hover {
-  background: linear-gradient(135deg, #e0f2fe 0%, #bae6fd 100%);
-  border-color: rgba(59, 130, 246, 0.2);
+  background: linear-gradient(135deg, var(--accent-bg) 0%, var(--accent-bg-4) 100%);
+  border-color: rgb(from var(--accent-strong) r g b / 0.2);
   transform: translateY(-6px);
   box-shadow:
-    0 12px 32px rgba(59, 130, 246, 0.15),
+    0 12px 32px rgb(from var(--accent-strong) r g b / 0.15),
     0 6px 16px rgba(0, 0, 0, 0.08);
 }
 
@@ -272,12 +272,12 @@ h1 {
 
 .tag {
   padding: 5px 12px;
-  background: linear-gradient(135deg, #dbeafe 0%, #bfdbfe 100%);
-  color: #1e40af;
+  background: linear-gradient(135deg, var(--accent-bg-2) 0%, var(--accent-bg-3) 100%);
+  color: var(--accent-ink);
   border-radius: var(--radius-full);
   font-size: 12px;
   font-weight: var(--font-weight-semibold);
-  border: 1px solid rgba(59, 130, 246, 0.2);
+  border: 1px solid rgb(from var(--accent-strong) r g b / 0.2);
 }
 
 .recipe-meta {
@@ -302,8 +302,8 @@ h1 {
 }
 
 .day-card {
-  background: linear-gradient(135deg, #f0f9ff 0%, #e0f2fe 100%);
-  border: 1px solid rgba(59, 130, 246, 0.15);
+  background: linear-gradient(135deg, var(--accent-bg-soft) 0%, var(--accent-bg) 100%);
+  border: 1px solid rgb(from var(--accent-strong) r g b / 0.15);
   border-radius: var(--radius-lg);
   padding: 10px;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.04);
@@ -314,14 +314,14 @@ h1 {
   font-weight: var(--font-weight-bold);
   font-size: 14px;
   margin-bottom: 8px;
-  color: #1e40af;
+  color: var(--accent-ink);
   text-align: center;
   letter-spacing: 0.01em;
 }
 
 .meal-slot {
   background: white;
-  border: 1px solid rgba(59, 130, 246, 0.1);
+  border: 1px solid rgb(from var(--accent-strong) r g b / 0.1);
   border-radius: var(--radius-md);
   padding: 9px 10px;
   margin-bottom: 8px;
@@ -439,7 +439,7 @@ h1 {
   font-size: 17px;
   font-weight: var(--font-weight-bold);
   margin-bottom: 14px;
-  color: #1e40af;
+  color: var(--accent-ink);
   display: flex;
   align-items: center;
   gap: 8px;
@@ -466,14 +466,14 @@ h1 {
   content: "✓";
   position: absolute;
   left: 0;
-  color: #0ea5e9;
+  color: var(--accent);
   font-weight: bold;
   font-size: 16px;
 }
 
 .ingredients-list li:hover {
   padding-left: 32px;
-  color: #1e40af;
+  color: var(--accent-ink);
 }
 
 .instructions-list p {
@@ -482,15 +482,15 @@ h1 {
 }
 
 .alert-info {
-  background: linear-gradient(135deg, #dbeafe 0%, #bfdbfe 100%);
-  border: 2px solid rgba(59, 130, 246, 0.2);
+  background: linear-gradient(135deg, var(--accent-bg-2) 0%, var(--accent-bg-3) 100%);
+  border: 2px solid rgb(from var(--accent-strong) r g b / 0.2);
   border-radius: var(--radius-lg);
   padding: 16px 20px;
   margin-bottom: 24px;
-  color: #1e40af;
+  color: var(--accent-ink);
   font-size: 14px;
   font-weight: var(--font-weight-medium);
-  box-shadow: 0 4px 12px rgba(59, 130, 246, 0.1);
+  box-shadow: 0 4px 12px rgb(from var(--accent-strong) r g b / 0.1);
 }
 
 /* ============================================
@@ -531,8 +531,8 @@ h1 {
   width: 24px;
   height: 24px;
   margin-left: 10px;
-  border: 3px solid #e0f2fe;
-  border-top-color: #3b82f6;
+  border: 3px solid var(--accent-bg);
+  border-top-color: var(--accent-strong);
   border-radius: 50%;
   animation: spin 0.8s linear infinite;
 }

--- a/eat.html
+++ b/eat.html
@@ -92,14 +92,14 @@
       }
 
       .btn-close {
-        background: rgba(59, 130, 246, 0.1);
+        background: rgb(from var(--accent-strong) r g b / 0.1);
         border: none;
         width: 36px;
         height: 36px;
         border-radius: var(--radius-full);
         cursor: pointer;
         font-size: 20px;
-        color: #0ea5e9;
+        color: var(--accent);
         transition: all var(--transition-fast);
         display: flex;
         align-items: center;
@@ -107,14 +107,14 @@
       }
       
       .btn-close:hover {
-        background: rgba(59, 130, 246, 0.2);
+        background: rgb(from var(--accent-strong) r g b / 0.2);
         transform: scale(1.1);
       }
       
       /* Boutons icônes pour les types */
       .type-icon-btn {
-        background: linear-gradient(135deg, #f0f9ff 0%, #e0f2fe 100%);
-        border: 2px solid rgba(59, 130, 246, 0.2);
+        background: linear-gradient(135deg, var(--accent-bg-soft) 0%, var(--accent-bg) 100%);
+        border: 2px solid rgb(from var(--accent-strong) r g b / 0.2);
         border-radius: var(--radius-xl);
         padding: 12px 16px;
         cursor: pointer;
@@ -128,16 +128,16 @@
       }
       
       .type-icon-btn:hover {
-        background: linear-gradient(135deg, #e0f2fe 0%, #bae6fd 100%);
+        background: linear-gradient(135deg, var(--accent-bg) 0%, var(--accent-bg-4) 100%);
         transform: translateY(-2px);
-        box-shadow: 0 4px 12px rgba(59, 130, 246, 0.2);
+        box-shadow: 0 4px 12px rgb(from var(--accent-strong) r g b / 0.2);
       }
       
       .type-icon-btn.active {
-        background: linear-gradient(135deg, #0ea5e9 0%, #3b82f6 100%);
+        background: linear-gradient(135deg, var(--accent) 0%, var(--accent-strong) 100%);
         color: white;
         border-color: transparent;
-        box-shadow: 0 4px 12px rgba(59, 130, 246, 0.3);
+        box-shadow: 0 4px 12px rgb(from var(--accent-strong) r g b / 0.3);
       }
       
       /* 🎯 Bouton retour planning (flèche) */
@@ -175,7 +175,7 @@
       }
       
       #filter-count {
-        color: #0ea5e9;
+        color: var(--accent);
         font-weight: var(--font-weight-bold);
       }
       
@@ -186,14 +186,14 @@
       }
       
       .meal-slot.clickable:hover {
-        background: linear-gradient(135deg, #dbeafe 0%, #bfdbfe 100%);
-        border-color: rgba(59, 130, 246, 0.3);
+        background: linear-gradient(135deg, var(--accent-bg-2) 0%, var(--accent-bg-3) 100%);
+        border-color: rgb(from var(--accent-strong) r g b / 0.3);
         transform: translateY(-2px);
-        box-shadow: 0 4px 12px rgba(59, 130, 246, 0.15);
+        box-shadow: 0 4px 12px rgb(from var(--accent-strong) r g b / 0.15);
       }
       
       .meal-slot.clickable .meal-content {
-        color: #0ea5e9;
+        color: var(--accent);
         font-weight: var(--font-weight-semibold);
       }
       


### PR DESCRIPTION
## Objectif

Rendre l'apparence facilement modifiable : centraliser le bleu d'accent (jusqu'ici codé en dur dans des dizaines d'endroits) en variables CSS, pour re-thémer depuis **un seul fichier** sans rien casser.

## Changements

- **`css/common.css`** : nouveau groupe de variables d'accent — `--accent`, `--accent-strong`, `--accent-ink`, `--accent-bg`/`-soft`/`-2…5`, `--gradient-blue`. Source unique de vérité.
- **`css/eat.css` + `<style>` de `eat.html`** : toutes les couleurs bleues en dur (`#0ea5e9`, `#3b82f6`, `#e0f2fe`, `#dbeafe`, `#bfdbfe`, `#f0f9ff`, `#bae6fd`, `#1e40af`…) remplacées par `var(--…)`. Les variantes translucides passent en *relative color syntax* `rgb(from var(--accent-strong) r g b / α)` : **valeurs identiques**, mais elles suivent désormais le changement de teinte.
- **`CLAUDE.md`** : section « Thème & couleurs » (procédure de re-thémage + statut par fichier).

## Périmètre

Cette passe couvre **eat** uniquement. `courses.html`/`courses.css` et `index.html` gardent des couleurs en dur (même traitement à prévoir). Le violet `.btn-accent` n'est pas encore tokenisé.

## Vérification (rendu identique)

Captures avant/après pilotées dans Chromium sur 3 écrans (accueil, modale recette, planning) : accueil et planning **byte-for-byte identiques**, modale identique sur tous les éléments colorés. Démo de re-thémage validée : surcharger `--accent`/`--accent-strong` recolore instantanément tout l'écran.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017EeGcqWUiDk6iWYMKhXWFH)_