### PR TITLE
Dark mode automatique (suit le réglage système)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,8 +177,13 @@ pages.
   sémantiques, ne suivent pas l'accent) : les rayons de courses
   (orange/jaune/rose/vert/gris), les cartes de la pyramide nutritionnelle, et les
   états d'erreur (rouge).
-- **Dark mode** : maintenant trivial — redéfinir les variables sous
-  `@media (prefers-color-scheme: dark)` dans `tokens.css`.
+- **Dark mode** : **actif**, en automatique (suit le réglage système via
+  `@media (prefers-color-scheme: dark)` dans `tokens.css` — seules des variables
+  y sont redéfinies, le mode clair reste intact). Les surfaces claires passent
+  par `--surface` / `--surface-2` (basculées en sombre). Note : les `<button>`
+  n'héritent pas de la couleur du `body` → ceux à fond neutre portent un
+  `color: var(--text-primary)` explicite (sinon texte noir illisible en sombre).
+  Les couleurs sémantiques (rayons, pyramide, erreurs) ne basculent pas.
 
 ## Conventions
 

--- a/courses.html
+++ b/courses.html
@@ -87,7 +87,8 @@
       }
       .toggle-btn {
         padding: 12px 28px;
-        background: rgba(255, 255, 255, 0.9);
+        color: var(--text-primary);
+        background: rgb(from var(--surface) r g b / 0.9);
         border: 2px solid rgb(from var(--accent-strong) r g b / 0.2);
         border-radius: var(--radius-full);
         cursor: pointer;
@@ -104,6 +105,7 @@
       /* === GRANDES CATÉGORIES === */
       .main-category-btn {
         padding: 14px 24px;
+        color: var(--text-primary);
         background: linear-gradient(135deg, var(--accent-bg-soft) 0%, var(--accent-bg) 100%);
         border: 2px solid rgb(from var(--accent-strong) r g b / 0.2);
         border-radius: var(--radius-xl);
@@ -286,7 +288,7 @@
         bottom: 0;
         width: 90%;
         max-width: 500px;
-        background: white;
+        background: var(--surface);
         box-shadow: -4px 0 32px rgba(0, 0, 0, 0.15);
         z-index: 1000;
         display: flex;
@@ -407,7 +409,7 @@
       }
 
       .shopping-category {
-        background: rgba(255, 255, 255, 0.95);
+        background: rgb(from var(--surface) r g b / 0.95);
         border: 1px solid rgb(from var(--accent-strong) r g b / 0.1);
         border-radius: var(--radius-xl);
         padding: 12px 16px;
@@ -517,7 +519,7 @@
         animation: fadeIn 0.2s ease-out;
       }
       .nutrition-modal-content {
-        background: white;
+        background: var(--surface);
         border-radius: var(--radius-2xl);
         max-width: 800px;
         width: 100%;
@@ -713,7 +715,7 @@
         animation: fadeIn 0.2s ease-out;
       }
       .confirm-content {
-        background: white;
+        background: var(--surface);
         border-radius: var(--radius-2xl);
         padding: 32px;
         max-width: 400px;
@@ -757,12 +759,12 @@
         box-shadow: 0 6px 20px rgba(239, 68, 68, 0.35);
       }
       .confirm-btn-secondary {
-        background: rgba(255, 255, 255, 0.9);
+        background: rgb(from var(--surface) r g b / 0.9);
         border: 2px solid rgba(0, 0, 0, 0.1);
         color: var(--text-primary);
       }
       .confirm-btn-secondary:hover {
-        background: white;
+        background: var(--surface);
         border-color: rgb(from var(--accent-strong) r g b / 0.2);
       }
 
@@ -861,13 +863,13 @@
       }
 
       .btn-compact-secondary {
-        background: rgba(255, 255, 255, 0.9);
+        background: rgb(from var(--surface) r g b / 0.9);
         border: 1px solid rgba(0, 0, 0, 0.1);
         color: var(--text-primary);
       }
 
       .btn-compact-secondary:hover {
-        background: white;
+        background: var(--surface);
         border-color: rgba(239, 68, 68, 0.3);
         color: #dc2626;
       }
@@ -1041,7 +1043,7 @@
       }
 
       .supermarket-close {
-        background: rgba(255, 255, 255, 0.2);
+        background: rgb(from var(--surface) r g b / 0.2);
         border: none;
         width: 36px;
         height: 36px;
@@ -1056,7 +1058,7 @@
       }
 
       .supermarket-close:hover {
-        background: rgba(255, 255, 255, 0.3);
+        background: rgb(from var(--surface) r g b / 0.3);
         transform: scale(1.1);
       }
 
@@ -1068,7 +1070,7 @@
       }
 
       .supermarket-category {
-        background: white;
+        background: var(--surface);
         border-radius: var(--radius-lg);
         padding: 12px 16px;
         margin-bottom: 12px;
@@ -1099,7 +1101,7 @@
         align-items: center;
         gap: 6px;
         padding: 8px 10px;
-        background: #f8fafc;
+        background: var(--surface-2);
         border-radius: var(--radius-md);
         transition: all var(--transition-fast);
         border: 1px solid transparent;
@@ -1132,7 +1134,7 @@
 
       .supermarket-item.checked {
         opacity: 0.4;
-        background: #f1f5f9;
+        background: var(--surface-2);
       }
 
       .supermarket-item.checked label {
@@ -1271,7 +1273,7 @@
       }
 
       .subcategory-fullscreen-close {
-        background: rgba(255, 255, 255, 0.2);
+        background: rgb(from var(--surface) r g b / 0.2);
         border: 2px solid rgba(255, 255, 255, 0.3);
         color: white;
         width: 44px;
@@ -1287,7 +1289,7 @@
       }
 
       .subcategory-fullscreen-close:hover {
-        background: rgba(255, 255, 255, 0.3);
+        background: rgb(from var(--surface) r g b / 0.3);
         transform: scale(1.1);
       }
 
@@ -1298,7 +1300,7 @@
       }
 
       .subcategory-card {
-        background: white;
+        background: var(--surface);
         border-radius: var(--radius-xl);
         padding: 20px;
         margin-bottom: 16px;

--- a/css/courses.css
+++ b/css/courses.css
@@ -7,10 +7,11 @@ body {
     165deg,
     var(--accent-bg-2) 0%,
     var(--accent-bg-5) 30%,
-    #ffffff 60%,
+    var(--surface) 60%,
     var(--accent-bg-soft) 100%
   );
   background-attachment: fixed;
+  color: var(--text-primary);
   padding: 40px 20px 80px;
 }
 
@@ -60,7 +61,7 @@ h1 {
    CARD
    ============================================ */
 .card {
-  background: rgba(255, 255, 255, 0.95);
+  background: rgb(from var(--surface) r g b / 0.95);
   backdrop-filter: blur(20px) saturate(180%);
   -webkit-backdrop-filter: blur(20px) saturate(180%);
   border: 1px solid rgba(255, 255, 255, 0.3);
@@ -90,7 +91,7 @@ h1 {
   border-radius: var(--radius-lg);
   font-size: 15px;
   font-family: inherit;
-  background: rgba(255, 255, 255, 0.9);
+  background: rgb(from var(--surface) r g b / 0.9);
   backdrop-filter: blur(8px);
   transition: all var(--transition-base);
   box-shadow: 
@@ -101,7 +102,7 @@ h1 {
 .add-item input:focus {
   outline: none;
   border-color: var(--accent-strong);
-  background: white;
+  background: var(--surface);
   box-shadow: 
     0 0 0 4px rgb(from var(--accent-strong) r g b / 0.1),
     0 4px 12px rgb(from var(--accent-strong) r g b / 0.15);
@@ -165,7 +166,7 @@ h1 {
 }
 
 .btn-secondary {
-  background: rgba(255, 255, 255, 0.9);
+  background: rgb(from var(--surface) r g b / 0.9);
   backdrop-filter: blur(8px);
   border: 2px solid rgba(0, 0, 0, 0.06);
   color: var(--text-primary);
@@ -173,7 +174,7 @@ h1 {
 }
 
 .btn-secondary:hover {
-  background: white;
+  background: var(--surface);
   border-color: rgb(from var(--accent-strong) r g b / 0.2);
   transform: translateY(-1px);
   box-shadow: 0 4px 12px rgb(from var(--accent-strong) r g b / 0.1);

--- a/css/eat.css
+++ b/css/eat.css
@@ -8,7 +8,7 @@ body {
     165deg,
     var(--accent-bg-2) 0%,
     var(--accent-bg-5) 30%,
-    #ffffff 60%,
+    var(--surface) 60%,
     var(--accent-bg-soft) 100%
   );
   background-attachment: fixed;
@@ -64,7 +64,7 @@ h1 {
    CARD & FILTRES
    ============================================ */
 .card {
-  background: rgba(255, 255, 255, 0.95);
+  background: rgb(from var(--surface) r g b / 0.95);
   backdrop-filter: blur(20px) saturate(180%);
   -webkit-backdrop-filter: blur(20px) saturate(180%);
   border: 1px solid rgba(255, 255, 255, 0.3);
@@ -105,7 +105,7 @@ h1 {
   border-radius: var(--radius-lg);
   font-size: 14px;
   font-family: inherit;
-  background: rgba(255, 255, 255, 0.9);
+  background: rgb(from var(--surface) r g b / 0.9);
   backdrop-filter: blur(8px);
   color: var(--text-primary);
   transition: all var(--transition-base);
@@ -118,7 +118,7 @@ h1 {
 .filter-group select:focus {
   outline: none;
   border-color: var(--accent-strong);
-  background: white;
+  background: var(--surface);
   box-shadow:
     0 0 0 4px rgb(from var(--accent-strong) r g b / 0.1),
     0 4px 12px rgb(from var(--accent-strong) r g b / 0.15);
@@ -177,7 +177,7 @@ h1 {
 }
 
 .btn-secondary {
-  background: rgba(255, 255, 255, 0.9);
+  background: rgb(from var(--surface) r g b / 0.9);
   backdrop-filter: blur(8px);
   color: var(--text-primary);
   border: 2px solid rgba(15, 23, 42, 0.16);
@@ -185,7 +185,7 @@ h1 {
 }
 
 .btn-secondary:hover {
-  background: white;
+  background: var(--surface);
   border-color: rgb(from var(--accent-strong) r g b / 0.2);
   transform: translateY(-1px);
   box-shadow: 0 4px 12px rgb(from var(--accent-strong) r g b / 0.1);
@@ -320,7 +320,7 @@ h1 {
 }
 
 .meal-slot {
-  background: white;
+  background: var(--surface);
   border: 1px solid rgb(from var(--accent-strong) r g b / 0.1);
   border-radius: var(--radius-md);
   padding: 9px 10px;
@@ -373,7 +373,7 @@ h1 {
 }
 
 .modal-content {
-  background: rgba(255, 255, 255, 0.98);
+  background: rgb(from var(--surface) r g b / 0.98);
   backdrop-filter: blur(20px);
   border: 1px solid rgba(255, 255, 255, 0.5);
   border-radius: var(--radius-2xl);

--- a/css/home.css
+++ b/css/home.css
@@ -7,17 +7,18 @@ body {
     165deg,
     #f3e8ff 0%,
     #faf5ff 30%,
-    #ffffff 60%,
+    var(--surface) 60%,
     #f8f9fe 100%
   );
   background-attachment: fixed;
+  color: var(--text-primary);
   overflow-x: hidden;
 }
 /* ============================================
    NAVBAR
    ============================================ */
 .navbar {
-  background: rgba(255, 255, 255, 0.9);
+  background: rgb(from var(--surface) r g b / 0.9);
   backdrop-filter: blur(20px) saturate(180%);
   -webkit-backdrop-filter: blur(20px) saturate(180%);
   border-bottom: 1px solid rgba(0, 0, 0, 0.06);
@@ -140,7 +141,7 @@ body {
   align-items: center;
   gap: 8px;
   padding: 12px 22px;
-  background: rgba(255, 255, 255, 0.8);
+  background: rgb(from var(--surface) r g b / 0.8);
   backdrop-filter: blur(8px);
   border: 2px solid rgba(0, 0, 0, 0.06);
   border-radius: var(--radius-full);
@@ -153,7 +154,7 @@ body {
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.04);
 }
 .logout-btn:hover {
-  background: rgba(255, 255, 255, 0.95);
+  background: rgb(from var(--surface) r g b / 0.95);
   border-color: rgba(239, 68, 68, 0.2);
   color: #dc2626;
   transform: translateY(-1px);
@@ -254,5 +255,20 @@ iframe {
   }
   .app-container {
     height: calc(100vh - 76px);
+  }
+}
+
+/* ============================================
+   MODE SOMBRE (suit le réglage système)
+   ============================================ */
+@media (prefers-color-scheme: dark) {
+  body {
+    background: linear-gradient(
+      165deg,
+      #1a1430 0%,
+      #16121f 30%,
+      var(--surface) 60%,
+      var(--bg-primary) 100%
+    );
   }
 }

--- a/css/tokens.css
+++ b/css/tokens.css
@@ -17,7 +17,11 @@
   --bg-tertiary: #f1f3f9;
   --bg-glass: rgba(255, 255, 255, 0.8);
   --bg-glass-dark: rgba(255, 255, 255, 0.95);
-  
+
+  /* Surfaces (cartes, modales, panneaux) — basculent en sombre */
+  --surface: #ffffff;   /* surface principale (cartes, modales, inputs) */
+  --surface-2: #f1f5f9; /* panneaux gris neutres */
+
   /* Textes */
   --text-primary: #1a202c;
   --text-secondary: #4a5568;
@@ -98,4 +102,43 @@
   /* Accent secondaire violet (bouton « Générer planning », .btn-accent) */
   --accent-2: #8b5cf6;
   --accent-2-strong: #6366f1;
+}
+
+/* ============================================
+   MODE SOMBRE (suit le réglage système)
+   On ne redéfinit QUE des variables : tout ce qui passe par var()
+   bascule automatiquement. Le mode clair reste intact.
+   ============================================ */
+@media (prefers-color-scheme: dark) {
+  :root {
+    /* Surfaces & fonds (slate bleuté, pas noir pur) */
+    --surface: #1b2431;
+    --surface-2: #141b26;
+    --bg-primary: #0f151e;
+    --bg-secondary: #1b2431;
+    --bg-tertiary: #141b26;
+    --bg-glass: rgba(27, 36, 49, 0.8);
+    --bg-glass-dark: rgba(27, 36, 49, 0.95);
+
+    /* Textes */
+    --text-primary: #e7ebf2;
+    --text-secondary: #aeb6c4;
+    --text-muted: #808a9c;
+    --text-inverse: #0f151e;
+
+    /* Accent : hues conservées, texte d'accent éclairci pour la lisibilité */
+    --accent-ink: #93c5fd;
+    --accent-bg-soft: #121a26;
+    --accent-bg: #15243a;
+    --accent-bg-2: #182c46;
+    --accent-bg-3: #1d3a5c;
+    --accent-bg-4: #244a72;
+    --accent-bg-5: #121a26;
+    --accent-300: #2c5480;
+
+    /* Bordures / focus adaptés au fond sombre */
+    --border-light: rgba(255, 255, 255, 0.08);
+    --border-medium: rgba(255, 255, 255, 0.14);
+    --border-focus: rgb(from var(--accent-strong) r g b / 0.5);
+  }
 }

--- a/eat.html
+++ b/eat.html
@@ -125,6 +125,7 @@
         align-items: center;
         gap: 4px;
         min-width: 80px;
+        color: var(--text-primary);
       }
       
       .type-icon-btn:hover {

--- a/index.html
+++ b/index.html
@@ -52,7 +52,7 @@
       }
 
       .login-card {
-        background: rgba(255, 255, 255, 0.95);
+        background: rgb(from var(--surface) r g b / 0.95);
         backdrop-filter: blur(20px) saturate(180%);
         border: 1px solid rgba(255, 255, 255, 0.3);
         border-radius: var(--radius-2xl);
@@ -116,7 +116,7 @@
         text-align: center;
         border: 2px solid rgb(from var(--brand-primary) r g b / 0.15);
         border-radius: 16px;
-        background: rgba(255, 255, 255, 0.8);
+        background: rgb(from var(--surface) r g b / 0.8);
         color: var(--text-primary);
         transition: all var(--transition-base);
       }
@@ -124,7 +124,7 @@
       .pin-digit:focus {
         outline: none;
         border-color: var(--brand-primary);
-        background: white;
+        background: var(--surface);
         box-shadow: 0 0 0 4px rgb(from var(--brand-primary) r g b / 0.1);
         transform: scale(1.05);
       }


### PR DESCRIPTION
## Objectif

Ajouter un mode sombre qui suit automatiquement le réglage système (iOS/desktop), sans bouton à gérer, en s'appuyant sur les variables du thème centralisées.

## Approche

- **`css/tokens.css`** : nouveaux tokens de surface (`--surface`, `--surface-2`) + un bloc `@media (prefers-color-scheme: dark)` qui **redéfinit uniquement des variables** (surfaces, textes, teintes d'accent, bordures). Le mode clair n'est pas touché → aucun risque de régression le jour.
- **Surfaces claires** (`white`, `rgba(255,255,255,α)`, gris neutres) → `var(--surface)` / `var(--surface-2)` via *relative color syntax*, dans `eat`/`courses`/`home`/`index`. Elles basculent donc en sombre automatiquement.
- **Correctif lisibilité** : les `<button>` n'héritent pas de la couleur du `body`. Les boutons à fond neutre (catégories, types de plat, toggle) reçoivent un `color: var(--text-primary)` explicite ; `color` ajouté aussi au `body` de `courses`/`home`.
- **`home.css`** : fond de page sombre dédié.

## Vérification

Pilotée dans Chromium (émulation `prefers-color-scheme`) :
- **Mode clair inchangé** (seule variation : texte noir par défaut `#000` → `#1a202c`, imperceptible).
- **Mode sombre lisible et cohérent** sur : accueil recettes, cartes, modale recette, planning, courses (catégories, sous-catégories, tiroir), écran PIN.

## Limites (poches secondaires)

Les couleurs **sémantiques** ne basculent pas (par choix) : rayons de courses, cartes de la pyramide nutritionnelle, états d'erreur. Le mode « supermarché » et la modale de confirmation n'ont pas été revus en détail — à ajuster si un panneau ressort trop clair.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017EeGcqWUiDk6iWYMKhXWFH)_