### PR TITLE
Thème : sélecteur Auto / Clair / Sombre

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,13 +177,17 @@ pages.
   sémantiques, ne suivent pas l'accent) : les rayons de courses
   (orange/jaune/rose/vert/gris), les cartes de la pyramide nutritionnelle, et les
   états d'erreur (rouge).
-- **Dark mode** : **actif**, en automatique (suit le réglage système via
-  `@media (prefers-color-scheme: dark)` dans `tokens.css` — seules des variables
-  y sont redéfinies, le mode clair reste intact). Les surfaces claires passent
-  par `--surface` / `--surface-2` (basculées en sombre). Note : les `<button>`
-  n'héritent pas de la couleur du `body` → ceux à fond neutre portent un
-  `color: var(--text-primary)` explicite (sinon texte noir illisible en sombre).
-  Les couleurs sémantiques (rayons, pyramide, erreurs) ne basculent pas.
+- **Dark mode** : **actif**, avec sélecteur **Auto / Clair / Sombre** (bouton
+  🌗 dans la navbar de `home.html`). Préférence dans
+  `localStorage['food_home_theme']` (`auto`|`light`|`dark`). `theme.js` (chargé
+  dans le `<head>` des 4 pages) résout la préférence — `auto` suit le système via
+  `matchMedia` — et pose `data-theme="light|dark"` sur `<html>`. Le sombre vit
+  dans `:root[data-theme="dark"]` de `tokens.css` (redéfinit seulement des
+  variables ; le clair reste intact). Le changement est propagé aux `<iframe>`
+  (`eat`/`courses`) par `postMessage({type:"THEME_CHANGED"})` + `localStorage`
+  partagé. Note : les `<button>` n'héritent pas de la couleur du `body` → ceux à
+  fond neutre portent un `color: var(--text-primary)` explicite. Les couleurs
+  sémantiques (rayons, pyramide, erreurs) ne basculent pas.
 
 ## Conventions
 

--- a/courses.html
+++ b/courses.html
@@ -27,6 +27,7 @@
     <title>FOOD HOME — Listes de courses</title>
     <link rel="stylesheet" href="/css/common.css" />
     <link rel="stylesheet" href="/css/courses.css" />
+    <script src="/theme.js"></script>
     <style>
       /* 🎨 COULEURS NUTRITIONNELLES - Styles dynamiques */
       .category-btn[data-color="blue"] {

--- a/css/tokens.css
+++ b/css/tokens.css
@@ -105,12 +105,12 @@
 }
 
 /* ============================================
-   MODE SOMBRE (suit le réglage système)
-   On ne redéfinit QUE des variables : tout ce qui passe par var()
-   bascule automatiquement. Le mode clair reste intact.
+   MODE SOMBRE
+   Activé par l'attribut data-theme="dark" sur <html>, posé par theme.js selon
+   la préférence (Auto → suit le système / Clair / Sombre). On ne redéfinit QUE
+   des variables : tout ce qui passe par var() bascule. Le clair reste intact.
    ============================================ */
-@media (prefers-color-scheme: dark) {
-  :root {
+:root[data-theme="dark"] {
     /* Surfaces & fonds (slate bleuté, pas noir pur) */
     --surface: #1b2431;
     --surface-2: #141b26;
@@ -140,5 +140,4 @@
     --border-light: rgba(255, 255, 255, 0.08);
     --border-medium: rgba(255, 255, 255, 0.14);
     --border-focus: rgb(from var(--accent-strong) r g b / 0.5);
-  }
 }

--- a/eat.html
+++ b/eat.html
@@ -24,6 +24,7 @@
     <!-- 🎨 CSS EXTERNES -->
     <link rel="stylesheet" href="/css/common.css">
     <link rel="stylesheet" href="/css/eat.css">
+    <script src="/theme.js"></script>
     <style>
       /* Toast notification */
       .toast {

--- a/home.html
+++ b/home.html
@@ -23,6 +23,7 @@
     <title>FOOD HOME - Application</title>
     <link rel="stylesheet" href="/css/common.css" />
     <link rel="stylesheet" href="/css/home.css" />
+    <script src="/theme.js"></script>
   </head>
   <body>
     <!-- Navigation Bar -->
@@ -32,6 +33,10 @@
         <span>FOOD HOME</span>
       </div>
       <div class="navbar-controls">
+        <button class="toggle-btn" id="themeBtn" onclick="cycleTheme()" title="Thème clair / sombre">
+          <span id="themeIcon">🌗</span>
+          <span id="themeText">Auto</span>
+        </button>
         <button class="toggle-btn" id="toggleBtn">
           <span id="toggleIcon">🔄</span>
           <span id="toggleText">Basculer</span>
@@ -164,6 +169,27 @@ window.addEventListener("load", () => {
   }
   console.log("✅ FOOD HOME loaded - postMessage communication ready");
 });
+
+// 🌗 Sélecteur de thème : cycle Auto → Clair → Sombre
+const THEME_ORDER = ["auto", "light", "dark"];
+const THEME_UI = {
+  auto:  { icon: "🌗", text: "Auto" },
+  light: { icon: "☀️", text: "Clair" },
+  dark:  { icon: "🌙", text: "Sombre" },
+};
+function refreshThemeButton() {
+  const pref = (window.getThemePref ? window.getThemePref() : "auto");
+  const ui = THEME_UI[pref] || THEME_UI.auto;
+  document.getElementById("themeIcon").textContent = ui.icon;
+  document.getElementById("themeText").textContent = ui.text;
+}
+function cycleTheme() {
+  const cur = (window.getThemePref ? window.getThemePref() : "auto");
+  const next = THEME_ORDER[(THEME_ORDER.indexOf(cur) + 1) % THEME_ORDER.length];
+  if (window.setThemePref) window.setThemePref(next); // applique + notifie les iframes
+  refreshThemeButton();
+}
+window.addEventListener("load", refreshThemeButton);
 
 // Fonction de déconnexion
 function logout() {

--- a/index.html
+++ b/index.html
@@ -21,6 +21,7 @@
     
     <title>FOOD HOME - Connexion</title>
     <link rel="stylesheet" href="/css/tokens.css" />
+    <script src="/theme.js"></script>
     <style>
 
       * {

--- a/theme.js
+++ b/theme.js
@@ -1,0 +1,53 @@
+/* ============================================
+   FOOD HOME - Thème clair/sombre
+   Préférence dans localStorage['food_home_theme'] : "auto" | "light" | "dark".
+   "auto" suit le réglage système. Pose data-theme="light|dark" sur <html>.
+   Chargé dans le <head> de chaque page (et des iframes) pour éviter le flash.
+   ============================================ */
+(function () {
+  var KEY = "food_home_theme";
+
+  function pref() {
+    try { return localStorage.getItem(KEY) || "auto"; } catch (e) { return "auto"; }
+  }
+  function systemDark() {
+    return !!(window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches);
+  }
+  function resolve(p) {
+    return p === "dark" || (p === "auto" && systemDark()) ? "dark" : "light";
+  }
+  function apply() {
+    document.documentElement.setAttribute("data-theme", resolve(pref()));
+  }
+
+  // API publique : change la préférence, applique, et notifie les iframes.
+  window.setThemePref = function (p) {
+    try {
+      if (p === "auto") localStorage.removeItem(KEY);
+      else localStorage.setItem(KEY, p);
+    } catch (e) {}
+    apply();
+    try {
+      var frames = document.querySelectorAll("iframe");
+      for (var i = 0; i < frames.length; i++) {
+        try { frames[i].contentWindow.postMessage({ type: "THEME_CHANGED" }, "*"); } catch (e) {}
+      }
+    } catch (e) {}
+  };
+  window.getThemePref = pref;
+
+  // Suivre le système quand on est en "auto".
+  if (window.matchMedia) {
+    try {
+      window.matchMedia("(prefers-color-scheme: dark)").addEventListener("change", function () {
+        if (pref() === "auto") apply();
+      });
+    } catch (e) {}
+  }
+  // Cas iframe : le parent notifie un changement -> ré-appliquer (localStorage partagé).
+  window.addEventListener("message", function (e) {
+    if (e && e.data && e.data.type === "THEME_CHANGED") apply();
+  });
+
+  apply();
+})();

--- a/vercel.json
+++ b/vercel.json
@@ -13,6 +13,10 @@
     {
       "source": "/css/(.*)",
       "headers": [{ "key": "Content-Type", "value": "text/css; charset=utf-8" }]
+    },
+    {
+      "source": "/theme.js",
+      "headers": [{ "key": "Content-Type", "value": "text/javascript; charset=utf-8" }]
     }
   ]
 }


### PR DESCRIPTION
## Objectif

Ajouter un réglage in-app pour choisir le thème (le mode sombre était jusque-là uniquement automatique). Bouton **🌗 Auto / Clair / Sombre** dans la barre du haut.

## Fonctionnement

- **`theme.js`** (nouveau, chargé dans le `<head>` des 4 pages, anti-flash) : lit la préférence `localStorage['food_home_theme']` (`auto` | `light` | `dark`), la résout (`auto` suit le système via `matchMedia`) et pose `data-theme="light|dark"` sur `<html>`. Expose `setThemePref()` / `getThemePref()`, suit les changements système en mode auto, et ré-applique sur `postMessage({type:"THEME_CHANGED"})`.
- **`tokens.css`** : le bloc sombre passe de `@media (prefers-color-scheme: dark)` à `:root[data-theme="dark"]` (piloté par `theme.js` ; l'auto est résolu côté JS). Le clair reste intact.
- **`home.html`** : bouton dans la navbar qui cycle **Auto → Clair → Sombre**, mémorise le choix et le **propage aux deux iframes** (`eat`/`courses`) via `postMessage` + `localStorage` partagé.
- **`vercel.json`** : `Content-Type` de `/theme.js`.

## Vérification

Pilotée dans Chromium :
- `auto` + système clair → clair ; `auto` + système sombre → sombre.
- Forçage `dark` en système clair → `data-theme=dark`, `--surface` sombre.
- Cycle depuis la navbar : **home + iframe eat + iframe courses basculent ensemble** (label du bouton mis à jour).

## Note

Le thème dépend désormais de `theme.js` (l'app requiert déjà JS). Préférence par défaut : `auto`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017EeGcqWUiDk6iWYMKhXWFH)_