### PR TITLE
Cartes de recettes visuelles avec photo (eat.html)

### DIFF
--- a/css/eat.css
+++ b/css/eat.css
@@ -231,28 +231,112 @@ h1 {
    ============================================ */
 #results {
   display: grid;
+  /* Desktop : ~3 colonnes dans le conteneur 960px ; mobile : 1 colonne (voir @media). */
   grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
   gap: 20px;
 }
 
 .recipe-card {
+  display: flex;
+  flex-direction: column;
   background: linear-gradient(135deg, var(--accent-bg-soft) 0%, var(--accent-bg) 100%);
   border: 1px solid rgb(from var(--accent-strong) r g b / 0.1);
   border-radius: var(--radius-xl);
-  padding: 20px;
+  overflow: hidden; /* rogne l'image au border-radius de la carte */
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.04);
   cursor: pointer;
-  transition: all var(--transition-base);
+  transition: transform var(--transition-base), box-shadow var(--transition-base),
+    border-color var(--transition-base);
   animation: slideInUp 0.3s ease-out;
+  /* Perf : n'affiche pas les cartes hors écran ; contain-intrinsic-size réserve
+     leur hauteur pour éviter le saut de scroll (hauteur cible ~360px). */
+  content-visibility: auto;
+  contain-intrinsic-size: auto 360px;
 }
 
 .recipe-card:hover {
-  background: linear-gradient(135deg, var(--accent-bg) 0%, var(--accent-bg-4) 100%);
   border-color: rgb(from var(--accent-strong) r g b / 0.2);
   transform: translateY(-6px);
   box-shadow:
     0 12px 32px rgb(from var(--accent-strong) r g b / 0.15),
     0 6px 16px rgba(0, 0, 0, 0.08);
+}
+
+/* --- Zone média : image en ratio 3/2 (~45 % de la hauteur de la carte) --- */
+.recipe-card__media {
+  position: relative;
+  aspect-ratio: 3 / 2;
+  overflow: hidden;
+  background: var(--accent-bg-2);
+  /* Shimmer d'attente tant que l'image n'est pas chargée (.is-loaded le coupe). */
+  background-image: linear-gradient(
+    100deg,
+    var(--accent-bg-2) 30%,
+    var(--accent-bg-soft) 50%,
+    var(--accent-bg-2) 70%
+  );
+  background-size: 200% 100%;
+  animation: shimmer 1.4s ease-in-out infinite;
+}
+
+.recipe-card__media.is-loaded {
+  animation: none;
+  background-image: none;
+}
+
+@keyframes shimmer {
+  from { background-position: 200% 0; }
+  to   { background-position: -200% 0; }
+}
+
+.recipe-card__image {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transition: transform var(--transition-slow);
+}
+
+/* Zoom léger au survol de l'image */
+.recipe-card:hover .recipe-card__image {
+  transform: scale(1.035);
+}
+
+/* Carte sans image : le placeholder est contenu (pas rogné) et ne zoome pas. */
+.recipe-card--no-image .recipe-card__image {
+  object-fit: contain;
+  padding: 22px;
+  opacity: 0.9;
+}
+
+.recipe-card--no-image:hover .recipe-card__image {
+  transform: none;
+}
+
+/* Badge temps ancré en bas-droite de l'image */
+.recipe-card__time {
+  position: absolute;
+  right: 10px;
+  bottom: 10px;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 10px;
+  background: rgb(from var(--surface) r g b / 0.92);
+  backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(6px);
+  color: var(--text-primary);
+  border-radius: var(--radius-full);
+  font-size: 12px;
+  font-weight: var(--font-weight-semibold);
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
+}
+
+/* --- Contenu : titre + badges + métadonnées --- */
+.recipe-card__content {
+  display: flex;
+  flex-direction: column;
+  padding: 16px 18px 18px;
 }
 
 .recipe-card h3 {
@@ -261,6 +345,13 @@ h1 {
   margin: 0 0 12px;
   color: var(--text-primary);
   line-height: 1.3;
+}
+
+/* Accessibilité : coupe les animations décoratives si l'utilisateur le demande. */
+@media (prefers-reduced-motion: reduce) {
+  .recipe-card__media { animation: none; }
+  .recipe-card__image,
+  .recipe-card:hover .recipe-card__image { transition: none; transform: none; }
 }
 
 .tags {
@@ -571,6 +662,7 @@ h1 {
   }
 
   #results {
+    /* Mobile : 1 colonne, image en pleine largeur. */
     grid-template-columns: 1fr;
   }
 
@@ -582,8 +674,8 @@ h1 {
     grid-template-columns: 1fr;
   }
 
-  .recipe-card {
-    padding: 18px;
+  .recipe-card__content {
+    padding: 16px 16px 18px;
   }
 
   .btn {

--- a/eat.html
+++ b/eat.html
@@ -382,6 +382,41 @@
       const SHOPPING_KEY = 'food_home_shopping_list';
 
       // ============================================
+      // IMAGES DES RECETTES
+      // ============================================
+      // Le chemin est DÉDUIT de l'id (images/recipes/pN.webp) — recipes.json n'est
+      // pas modifié. Les images n'existent pas encore : la gestion d'erreur (plus
+      // bas) bascule sur un placeholder inline si le .webp est absent.
+      function getRecipeImage(recipe) {
+        return `images/recipes/${recipe.id}.webp`;
+      }
+
+      // Placeholder en data-URI SVG : aucune dépendance réseau ni fichier binaire,
+      // donc jamais d'icône « image cassée » même quand tous les .webp manquent.
+      const PLACEHOLDER_SVG =
+        `<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 120 80'>` +
+        `<g fill='none' stroke='#94a3b8' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'>` +
+        `<circle cx='60' cy='40' r='19'/><circle cx='60' cy='40' r='11'/>` +
+        `<path d='M25 20v13M30 20v13M35 20v13'/>` +
+        `<path d='M25 33c0 5 2.5 6 5 6s5-1 5-6'/><path d='M30 39v20'/>` +
+        `<path d='M92 20c-6 4-6 16 0 20'/><path d='M92 40v19'/>` +
+        `</g></svg>`;
+      const PLACEHOLDER_IMAGE =
+        "data:image/svg+xml;utf8," + encodeURIComponent(PLACEHOLDER_SVG);
+
+      // Nombre de cartes « above the fold » chargées en priorité (eager + high).
+      const EAGER_IMAGE_COUNT = 6;
+
+      // Échappe une valeur destinée à un attribut HTML (alt, etc.).
+      function escapeAttr(s) {
+        return (s || "")
+          .replace(/&/g, "&amp;")
+          .replace(/"/g, "&quot;")
+          .replace(/</g, "&lt;")
+          .replace(/>/g, "&gt;");
+      }
+
+      // ============================================
       // VARIABLES GLOBALES
       // ============================================
       let allRecipes = [];
@@ -548,33 +583,47 @@
             '<div class="empty">😔 Aucune recette trouvée avec ces filtres</div>';
           return;
         }
-        recipes.forEach((recipe) => {
-          const card = createRecipeCard(recipe);
+        recipes.forEach((recipe, index) => {
+          const card = createRecipeCard(recipe, index);
           resultsDiv.appendChild(card);
         });
       }
-      function createRecipeCard(recipe) {
+      function createRecipeCard(recipe, index = 0) {
         const card = document.createElement("article");
         card.className = "recipe-card";
         card.onclick = () => openRecipeModal(recipe);
         const saisons = recipe.saisons.split("|").filter((s) => s);
         const diets = recipe.diets.split("|").filter((d) => d);
         const typeIcon = getTypeIcon(recipe.type_repas);
+        // 6 premières cartes = above the fold → chargement prioritaire.
+        const eager = index < EAGER_IMAGE_COUNT;
+        const alt = escapeAttr(recipe.imageAlt || recipe.nom);
+        // La gestion d'erreur est déléguée au document (capture), pas d'onerror inline.
         card.innerHTML = `
-          <h3>${typeIcon} ${recipe.nom}</h3>
-          <div class="tags">
-            ${saisons.map((s) => `<span class="tag">${s}</span>`).join("")}
-            ${diets
-              .slice(0, 2)
-              .map((d) => `<span class="tag">${d}</span>`)
-              .join("")}
+          <div class="recipe-card__media">
+            <img class="recipe-card__image"
+                 src="${getRecipeImage(recipe)}"
+                 alt="${alt}"
+                 width="800" height="533"
+                 decoding="async"
+                 loading="${eager ? "eager" : "lazy"}"${eager ? ' fetchpriority="high"' : ""} />
+            <span class="recipe-card__time">⏱️ ${recipe.temps} min</span>
           </div>
-          <div class="recipe-meta">
-            <span>⏱️ ${recipe.temps} min</span>
-            <span>🥩 ${recipe.proteine}</span>
-            ${recipe.public === "kids" ? "<span>👶 Kids</span>" : ""}
-            ${recipe.public === "adultes" ? "<span>🍷 Adultes</span>" : ""}
-            ${recipe.moment === "we" ? "<span>🗓️ WE</span>" : ""}
+          <div class="recipe-card__content">
+            <h3>${typeIcon} ${recipe.nom}</h3>
+            <div class="tags">
+              ${saisons.map((s) => `<span class="tag">${s}</span>`).join("")}
+              ${diets
+                .slice(0, 2)
+                .map((d) => `<span class="tag">${d}</span>`)
+                .join("")}
+            </div>
+            <div class="recipe-meta">
+              <span>🥩 ${recipe.proteine}</span>
+              ${recipe.public === "kids" ? "<span>👶 Kids</span>" : ""}
+              ${recipe.public === "adultes" ? "<span>🍷 Adultes</span>" : ""}
+              ${recipe.moment === "we" ? "<span>🗓️ WE</span>" : ""}
+            </div>
           </div>
         `;
         return card;
@@ -973,6 +1022,38 @@
           if (planningModal.classList.contains("active")) closePlanningModal();
         }
       });
+      // ============================================
+      // GESTION CENTRALISÉE DES IMAGES DE RECETTES
+      // ============================================
+      // load/error ne bouillonnent pas → capture=true pour les intercepter au
+      // niveau document (aucun onerror inline dans le HTML généré).
+      document.addEventListener(
+        "load",
+        (e) => {
+          const img = e.target;
+          if (img && img.classList && img.classList.contains("recipe-card__image")) {
+            const media = img.closest(".recipe-card__media");
+            if (media) media.classList.add("is-loaded"); // coupe le shimmer
+          }
+        },
+        true
+      );
+      document.addEventListener(
+        "error",
+        (e) => {
+          const img = e.target;
+          if (!img || !img.classList || !img.classList.contains("recipe-card__image")) return;
+          if (img.dataset.fallback === "done") return; // évite toute boucle
+          img.dataset.fallback = "done";
+          img.src = PLACEHOLDER_IMAGE;
+          const media = img.closest(".recipe-card__media");
+          if (media) media.classList.add("is-loaded");
+          const card = img.closest(".recipe-card");
+          if (card) card.classList.add("recipe-card--no-image");
+        },
+        true
+      );
+
       // ============================================
       // ============================================
       // INIT

--- a/images/recipes/README.md
+++ b/images/recipes/README.md
@@ -1,0 +1,50 @@
+# Images des recettes
+
+Photos des cartes de recettes affichées dans `eat.html`.
+
+## Convention de nommage
+
+Une image par recette, **nommée d'après son `id`** dans `recipes.json` :
+
+```
+images/recipes/<id>.webp        ex. images/recipes/p1.webp, p2.webp, … p175.webp
+```
+
+Le chemin est **déduit de l'id** côté code (`getRecipeImage()` dans `eat.html`) —
+il ne faut **pas** ajouter de champ image dans `recipes.json`.
+
+## Spécifications des fichiers
+
+| Paramètre      | Valeur                                             |
+|----------------|----------------------------------------------------|
+| Format         | WebP                                               |
+| Ratio          | 3:2 (paysage)                                       |
+| Dimensions     | ~800 × 533 px (cible ; les cartes affichent en 3/2)|
+| Qualité        | 78–82 (bon compromis netteté / poids)              |
+| Poids indicatif| < 60–80 Ko par image                               |
+| Cadrage        | Plat centré, marge respirable (l'affichage rogne en `object-fit: cover`) |
+
+Les attributs `width="800"` / `height="533"` sont posés sur chaque `<img>` pour
+réserver l'espace et éviter le CLS (layout shift) — garder ce ratio 3:2.
+
+## Absence d'image
+
+Les images peuvent être ajoutées **progressivement**. Tant qu'un `<id>.webp`
+n'existe pas :
+
+- la carte affiche le **placeholder inline** (SVG data-URI, défini dans
+  `eat.html`) — aucune icône « image cassée », aucun layout shift ;
+- la carte reçoit la classe `.recipe-card--no-image` pour un style différencié ;
+- `placeholder.svg` (ce dossier) est la version autonome du même visuel, utile
+  pour prévisualiser ou générer un placeholder.webp si besoin.
+
+## Génération future (hors de ce ticket)
+
+Les scripts d'aide (`tools/generate-image-prompts.js`, `tools/optimize-images.js`)
+seront ajoutés séparément. Pour convertir/optimiser manuellement une image en
+respectant les specs ci-dessus :
+
+```sh
+# Exemple avec cwebp (libwebp) : redimensionne à 800px de large et qualité 80
+cwebp -q 80 -resize 800 0 source.jpg -o images/recipes/p1.webp
+```

--- a/images/recipes/placeholder.svg
+++ b/images/recipes/placeholder.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 80" role="img" aria-label="Photo de recette à venir">
+  <rect width="120" height="80" rx="10" fill="#e0f2fe"/>
+  <g fill="none" stroke="#94a3b8" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+    <!-- Assiette -->
+    <circle cx="60" cy="40" r="19"/>
+    <circle cx="60" cy="40" r="11"/>
+    <!-- Fourchette (gauche) -->
+    <path d="M25 20v13M30 20v13M35 20v13"/>
+    <path d="M25 33c0 5 2.5 6 5 6s5-1 5-6"/>
+    <path d="M30 39v20"/>
+    <!-- Couteau (droite) -->
+    <path d="M92 20c-6 4-6 16 0 20"/>
+    <path d="M92 40v19"/>
+  </g>
+</svg>


### PR DESCRIPTION
## Objectif

Transforme chaque carte de recette (`eat.html`) en carte visuelle avec photo, tout en préservant l'existant (filtres, badges, métadonnées, recherche/tri).

## ✅ Mergeable dès maintenant, sans aucune image

Aucune photo n'existe encore, **et c'est prévu** : le code tolère l'absence complète des images.

- Un `.webp` manquant → requête 404 inoffensive, interceptée par un handler d'erreur global (capture) qui bascule sur un **placeholder SVG inline** (data-URI, aucune dépendance réseau). Jamais d'icône « image cassée », **aucun layout shift** (ratio 3/2 réservé d'avance).
- Site 100 % statique, pas de build ni de CI : un 404 sur une image **n'empêche pas** le déploiement Vercel.
- Les vraies photos `images/recipes/pN.webp` peuvent être ajoutées **progressivement, une par une** — chaque carte affiche sa photo dès que le fichier existe, les autres gardent le placeholder.

## Changements

**Carte** (`css/eat.css`)
- Structure `.recipe-card__media` (aspect-ratio 3/2) + `.recipe-card__content`.
- Image `object-fit: cover`, zoom léger (1.035) au survol.
- Badge temps ⏱️ ancré en absolute bas-droite de l'image.
- Desktop ~3 colonnes / mobile 1 colonne, image pleine largeur.
- Perf : `content-visibility: auto` + `contain-intrinsic-size`, shimmer d'attente retiré via `.is-loaded`, `prefers-reduced-motion` respecté.
- Réutilise **strictement** les tokens existants de `tokens.css` (aucune variable inventée), compatible dark mode.

**Rendu** (`eat.html`)
- Chemin déduit de l'id : `getRecipeImage()` → `images/recipes/<id>.webp`. **`recipes.json` inchangé.**
- `<img>` : `alt` (fallback `nom`), `width/height` intrinsèques (800×533, anti-CLS), `decoding="async"`, `loading="lazy"` par défaut, `loading="eager"` + `fetchpriority="high"` sur les **6 premières** cartes.
- Fallback centralisé au document (pas d'`onerror` inline) : placeholder + classe `.recipe-card--no-image`.
- Tous les badges/métadonnées existants conservés.

**Assets**
- `images/recipes/` : `placeholder.svg` + `README.md` (convention `pN.webp`, ratio 3:2, ~800×533, qualité 78–82).

## Vérification

Testé au navigateur (Playwright/Chromium) **sans aucune vraie image** : 167 cartes rendues avec placeholder, filtres intacts (Plat → 131, recherche « poulet » → 35), tri/recherche non touchés, pas d'image cassée ni de saut de scroll.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pa4V7HDUnco8wcseoBJRnE)_