### PR TITLE
Cartes recettes en ratio 4/5 portrait

### DIFF
--- a/css/eat.css
+++ b/css/eat.css
@@ -251,7 +251,7 @@ h1 {
   /* Perf : n'affiche pas les cartes hors écran ; contain-intrinsic-size réserve
      leur hauteur pour éviter le saut de scroll (hauteur cible ~360px). */
   content-visibility: auto;
-  contain-intrinsic-size: auto 360px;
+  contain-intrinsic-size: auto 520px;
 }
 
 .recipe-card:hover {
@@ -262,10 +262,10 @@ h1 {
     0 6px 16px rgba(0, 0, 0, 0.08);
 }
 
-/* --- Zone média : image en ratio 3/2 (~45 % de la hauteur de la carte) --- */
+/* --- Zone média : image en ratio 4/5 portrait (style éditorial rustique) --- */
 .recipe-card__media {
   position: relative;
-  aspect-ratio: 3 / 2;
+  aspect-ratio: 4 / 5;
   overflow: hidden;
   background: var(--accent-bg-2);
   /* Shimmer d'attente tant que l'image n'est pas chargée (.is-loaded le coupe). */

--- a/eat.html
+++ b/eat.html
@@ -394,12 +394,12 @@
       // Placeholder en data-URI SVG : aucune dépendance réseau ni fichier binaire,
       // donc jamais d'icône « image cassée » même quand tous les .webp manquent.
       const PLACEHOLDER_SVG =
-        `<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 120 80'>` +
+        `<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 96 120'>` +
         `<g fill='none' stroke='#94a3b8' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'>` +
-        `<circle cx='60' cy='40' r='19'/><circle cx='60' cy='40' r='11'/>` +
-        `<path d='M25 20v13M30 20v13M35 20v13'/>` +
-        `<path d='M25 33c0 5 2.5 6 5 6s5-1 5-6'/><path d='M30 39v20'/>` +
-        `<path d='M92 20c-6 4-6 16 0 20'/><path d='M92 40v19'/>` +
+        `<circle cx='48' cy='58' r='21'/><circle cx='48' cy='58' r='12'/>` +
+        `<path d='M13 26v15M18 26v15M23 26v15'/>` +
+        `<path d='M13 41c0 5 2.5 6 5 6s5-1 5-6'/><path d='M18 47v46'/>` +
+        `<path d='M78 26c-6 4-6 17 0 22'/><path d='M78 48v45'/>` +
         `</g></svg>`;
       const PLACEHOLDER_IMAGE =
         "data:image/svg+xml;utf8," + encodeURIComponent(PLACEHOLDER_SVG);
@@ -604,7 +604,7 @@
             <img class="recipe-card__image"
                  src="${getRecipeImage(recipe)}"
                  alt="${alt}"
-                 width="800" height="533"
+                 width="720" height="900"
                  decoding="async"
                  loading="${eager ? "eager" : "lazy"}"${eager ? ' fetchpriority="high"' : ""} />
             <span class="recipe-card__time">⏱️ ${recipe.temps} min</span>

--- a/images/recipes/README.md
+++ b/images/recipes/README.md
@@ -18,14 +18,14 @@ il ne faut **pas** ajouter de champ image dans `recipes.json`.
 | Paramètre      | Valeur                                             |
 |----------------|----------------------------------------------------|
 | Format         | WebP                                               |
-| Ratio          | 3:2 (paysage)                                       |
-| Dimensions     | ~800 × 533 px (cible ; les cartes affichent en 3/2)|
+| Ratio          | 4:5 (portrait)                                      |
+| Dimensions     | ~720 × 900 px (cible ; les cartes affichent en 4/5)|
 | Qualité        | 78–82 (bon compromis netteté / poids)              |
 | Poids indicatif| < 60–80 Ko par image                               |
 | Cadrage        | Plat centré, marge respirable (l'affichage rogne en `object-fit: cover`) |
 
-Les attributs `width="800"` / `height="533"` sont posés sur chaque `<img>` pour
-réserver l'espace et éviter le CLS (layout shift) — garder ce ratio 3:2.
+Les attributs `width="720"` / `height="900"` sont posés sur chaque `<img>` pour
+réserver l'espace et éviter le CLS (layout shift) — garder ce ratio 4:5.
 
 ## Absence d'image
 
@@ -45,6 +45,6 @@ seront ajoutés séparément. Pour convertir/optimiser manuellement une image en
 respectant les specs ci-dessus :
 
 ```sh
-# Exemple avec cwebp (libwebp) : redimensionne à 800px de large et qualité 80
-cwebp -q 80 -resize 800 0 source.jpg -o images/recipes/p1.webp
+# Exemple avec cwebp (libwebp) : redimensionne à 720px de large et qualité 80
+cwebp -q 80 -resize 720 0 source.jpg -o images/recipes/p1.webp
 ```

--- a/images/recipes/placeholder.svg
+++ b/images/recipes/placeholder.svg
@@ -1,15 +1,15 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 80" role="img" aria-label="Photo de recette à venir">
-  <rect width="120" height="80" rx="10" fill="#e0f2fe"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 96 120" role="img" aria-label="Photo de recette à venir">
+  <rect width="96" height="120" rx="10" fill="#e0f2fe"/>
   <g fill="none" stroke="#94a3b8" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
     <!-- Assiette -->
-    <circle cx="60" cy="40" r="19"/>
-    <circle cx="60" cy="40" r="11"/>
+    <circle cx="48" cy="58" r="21"/>
+    <circle cx="48" cy="58" r="12"/>
     <!-- Fourchette (gauche) -->
-    <path d="M25 20v13M30 20v13M35 20v13"/>
-    <path d="M25 33c0 5 2.5 6 5 6s5-1 5-6"/>
-    <path d="M30 39v20"/>
+    <path d="M13 26v15M18 26v15M23 26v15"/>
+    <path d="M13 41c0 5 2.5 6 5 6s5-1 5-6"/>
+    <path d="M18 47v46"/>
     <!-- Couteau (droite) -->
-    <path d="M92 20c-6 4-6 16 0 20"/>
-    <path d="M92 40v19"/>
+    <path d="M78 26c-6 4-6 17 0 22"/>
+    <path d="M78 48v45"/>
   </g>
 </svg>


### PR DESCRIPTION
## Objectif

Basculer les cartes de recettes du ratio **3/2 paysage** au **4/5 portrait**. Le crop 3/2 détruisait la mise en scène des photos portrait natives (ingrédients en second plan et textile perdus).

## ✅ Mergeable dès maintenant, sans image

Le comportement de tolérance à l'absence d'image (introduit en #24) est inchangé : sans `.webp`, la carte affiche le placeholder — désormais lui aussi en 4:5, donc **aucun layout shift** entre placeholder et image chargée. Les 15 premières photos peuvent arriver juste après.

## Changements

**`css/eat.css`**
- `.recipe-card__media` : `aspect-ratio` 3/2 → **4/5**.
- `.recipe-card` : `contain-intrinsic-size` `auto 360px` → **`auto 520px`** (image plus haute + contenu).
- Shimmer d'attente et zoom au survol inchangés (ratio-agnostiques).

**`eat.html`**
- `<img.recipe-card__image>` : attributs intrinsèques **`width="720" height="900"`** (au lieu de 800×533) pour éviter le CLS. `loading` lazy/eager conditionnel et `fetchpriority="high"` **inchangés**.
- Placeholder SVG inline : `viewBox` **`0 0 96 120`** (4:5).

**`images/recipes/`**
- `placeholder.svg` : viewBox 96×120 (4:5).
- `README.md` : specs mises à jour (ratio 4:5, ~720×900).

## Vérification

Testé au navigateur (Playwright/Chromium) : ratio média mesuré **exactement 0.800** (= 4/5), attributs `<img>` 720×900, grille desktop 3 colonnes harmonieuse (cartes plus hautes, attendu), placeholder plein cadre esthétique, filtres/recherche/tri intacts (Plat → 131). Aucune variable CSS inventée, pas d'`onerror` inline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pa4V7HDUnco8wcseoBJRnE)_