### PR TITLE
Bouton flottant « Filtres » accessible après scroll

### DIFF
--- a/eat.html
+++ b/eat.html
@@ -202,7 +202,63 @@
       .meal-slot.clickable:hover .meal-content {
         text-decoration: underline;
       }
-      
+
+      /* 🎯 Bouton flottant : accès rapide aux filtres après scroll */
+      .fab-filters {
+        position: fixed;
+        right: 20px;
+        bottom: 20px;
+        z-index: 900;
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        padding: 12px 18px;
+        border: none;
+        border-radius: var(--radius-full);
+        background: linear-gradient(135deg, var(--accent) 0%, var(--accent-strong) 100%);
+        color: #fff;
+        font-family: inherit;
+        font-size: 15px;
+        font-weight: var(--font-weight-semibold);
+        cursor: pointer;
+        box-shadow: 0 8px 24px rgb(from var(--accent-strong) r g b / 0.4);
+        opacity: 0;
+        transform: translateY(20px) scale(0.9);
+        pointer-events: none;
+        transition: opacity var(--transition-base),
+          transform var(--transition-base),
+          box-shadow var(--transition-fast);
+      }
+
+      .fab-filters.visible {
+        opacity: 1;
+        transform: translateY(0) scale(1);
+        pointer-events: auto;
+      }
+
+      .fab-filters:hover {
+        box-shadow: 0 10px 28px rgb(from var(--accent-strong) r g b / 0.55);
+        transform: translateY(-2px) scale(1.03);
+      }
+
+      .fab-filters:active {
+        transform: translateY(0) scale(0.98);
+      }
+
+      .fab-filters .fab-icon {
+        font-size: 18px;
+        line-height: 1;
+      }
+
+      /* Mobile : plus compact + safe-area iOS */
+      @media (max-width: 768px) {
+        .fab-filters {
+          right: 16px;
+          bottom: calc(16px + env(safe-area-inset-bottom, 0px));
+          padding: 12px 16px;
+        }
+      }
+
     </style>
   </head>
   <body>
@@ -307,6 +363,20 @@
         <div class="loading">Chargement des recettes...</div>
       </div>
     </div>
+
+    <!-- 🎯 Bouton flottant : revenir aux filtres sans tout remonter -->
+    <button
+      id="fab-filters"
+      class="fab-filters"
+      type="button"
+      onclick="scrollToFilters()"
+      aria-label="Aller aux filtres"
+      title="Filtres"
+    >
+      <span class="fab-icon" aria-hidden="true">🔍</span>
+      <span class="fab-label">Filtres</span>
+    </button>
+
     <!-- Modal détail recette -->
     <div class="modal" id="recipeModal">
       <div class="modal-content">
@@ -1146,7 +1216,30 @@
           advancedFilters.style.display = isVisible ? 'none' : 'block';
           icon.textContent = isVisible ? '+' : '−';
         }
-        
+
+        // 🎯 Bouton flottant : visible dès qu'on a scrollé, ramène aux filtres
+        const fabFilters = document.getElementById('fab-filters');
+        function updateFabVisibility() {
+          if (window.scrollY > 350) {
+            fabFilters.classList.add('visible');
+          } else {
+            fabFilters.classList.remove('visible');
+          }
+        }
+        window.addEventListener('scroll', updateFabVisibility, { passive: true });
+        updateFabVisibility();
+
+        function scrollToFilters() {
+          // Ouvre les filtres avancés pour tout afficher (saison / régime / protéine)
+          const advancedFilters = document.getElementById('advancedFilters');
+          const icon = document.getElementById('filter-toggle-icon');
+          if (advancedFilters && advancedFilters.style.display === 'none') {
+            advancedFilters.style.display = 'block';
+            if (icon) icon.textContent = '−';
+          }
+          window.scrollTo({ top: 0, behavior: 'smooth' });
+        }
+
         // Mettre à jour le compteur de filtres actifs
         function updateFilterCount() {
           const saison = saisonSelect.value;


### PR DESCRIPTION
## Problème

Sur `eat.html`, les filtres (entrée/plat/dessert, saison, régime, protéine) sont en haut de page. Dès qu'on fait défiler le catalogue de recettes, ils sortent du champ de vision, obligeant à tout remonter pour changer un filtre — pénible sur ordi comme sur smartphone.

## Solution

Ajout d'un **bouton flottant « 🔍 Filtres »** (bas-droite) dans `eat.html` :

- Caché en haut de page, il **apparaît en douceur dès qu'on a scrollé** (au-delà de ~350 px).
- Au clic : **remontée fluide** vers les filtres **et** ouverture automatique du panneau avancé, donc saison / régime / protéine sont directement accessibles.
- Auto-contenu dans l'iframe `eat`, fonctionne à l'identique **sur ordi et mobile** (gestion du safe-area iOS).
- Utilise les tokens du thème (`--accent`, `--radius-full`, etc.) — suit automatiquement le re-thémage et le dark mode.

Le sélecteur de thème « Auto » du navbar est **conservé** (il pilote Auto/Clair/Sombre) : le bouton flottant vit dans la page des recettes, sans couplage cross-iframe.

## Test

Vérifié au navigateur : invisible en haut, cliquable après scroll, remontée à 0 avec le panneau de filtres ouvert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqD9prxnyjHX7z3UdLjqQP)_