### PR TITLE
Fix : bouton flottant « Filtres » invisible sur mobile

### DIFF
--- a/css/home.css
+++ b/css/home.css
@@ -259,6 +259,60 @@ iframe {
 }
 
 /* ============================================
+   BOUTON FLOTTANT « FILTRES » (page Repas)
+   ============================================ */
+.fab-filters {
+  position: fixed;
+  right: 20px;
+  bottom: 20px;
+  z-index: 900;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 18px;
+  border: none;
+  border-radius: var(--radius-full);
+  background: linear-gradient(135deg, var(--accent) 0%, var(--accent-strong) 100%);
+  color: #fff;
+  font-family: inherit;
+  font-size: 15px;
+  font-weight: var(--font-weight-semibold);
+  cursor: pointer;
+  box-shadow: 0 8px 24px rgb(from var(--accent-strong) r g b / 0.4);
+  opacity: 0;
+  transform: translateY(20px) scale(0.9);
+  pointer-events: none;
+  transition:
+    opacity var(--transition-base),
+    transform var(--transition-base),
+    box-shadow var(--transition-fast);
+}
+.fab-filters.visible {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+  pointer-events: auto;
+}
+.fab-filters:hover {
+  box-shadow: 0 10px 28px rgb(from var(--accent-strong) r g b / 0.55);
+  transform: translateY(-2px) scale(1.03);
+}
+.fab-filters:active {
+  transform: translateY(0) scale(0.98);
+}
+.fab-filters .fab-icon {
+  font-size: 18px;
+  line-height: 1;
+}
+/* Mobile : plus compact + safe-area iOS */
+@media (max-width: 768px) {
+  .fab-filters {
+    right: 16px;
+    bottom: calc(16px + env(safe-area-inset-bottom, 0px));
+    padding: 12px 16px;
+  }
+}
+
+/* ============================================
    MODE SOMBRE (suit le réglage système)
    ============================================ */
 @media (prefers-color-scheme: dark) {

--- a/eat.html
+++ b/eat.html
@@ -203,62 +203,6 @@
         text-decoration: underline;
       }
 
-      /* 🎯 Bouton flottant : accès rapide aux filtres après scroll */
-      .fab-filters {
-        position: fixed;
-        right: 20px;
-        bottom: 20px;
-        z-index: 900;
-        display: flex;
-        align-items: center;
-        gap: 8px;
-        padding: 12px 18px;
-        border: none;
-        border-radius: var(--radius-full);
-        background: linear-gradient(135deg, var(--accent) 0%, var(--accent-strong) 100%);
-        color: #fff;
-        font-family: inherit;
-        font-size: 15px;
-        font-weight: var(--font-weight-semibold);
-        cursor: pointer;
-        box-shadow: 0 8px 24px rgb(from var(--accent-strong) r g b / 0.4);
-        opacity: 0;
-        transform: translateY(20px) scale(0.9);
-        pointer-events: none;
-        transition: opacity var(--transition-base),
-          transform var(--transition-base),
-          box-shadow var(--transition-fast);
-      }
-
-      .fab-filters.visible {
-        opacity: 1;
-        transform: translateY(0) scale(1);
-        pointer-events: auto;
-      }
-
-      .fab-filters:hover {
-        box-shadow: 0 10px 28px rgb(from var(--accent-strong) r g b / 0.55);
-        transform: translateY(-2px) scale(1.03);
-      }
-
-      .fab-filters:active {
-        transform: translateY(0) scale(0.98);
-      }
-
-      .fab-filters .fab-icon {
-        font-size: 18px;
-        line-height: 1;
-      }
-
-      /* Mobile : plus compact + safe-area iOS */
-      @media (max-width: 768px) {
-        .fab-filters {
-          right: 16px;
-          bottom: calc(16px + env(safe-area-inset-bottom, 0px));
-          padding: 12px 16px;
-        }
-      }
-
     </style>
   </head>
   <body>
@@ -363,19 +307,6 @@
         <div class="loading">Chargement des recettes...</div>
       </div>
     </div>
-
-    <!-- 🎯 Bouton flottant : revenir aux filtres sans tout remonter -->
-    <button
-      id="fab-filters"
-      class="fab-filters"
-      type="button"
-      onclick="scrollToFilters()"
-      aria-label="Aller aux filtres"
-      title="Filtres"
-    >
-      <span class="fab-icon" aria-hidden="true">🔍</span>
-      <span class="fab-label">Filtres</span>
-    </button>
 
     <!-- Modal détail recette -->
     <div class="modal" id="recipeModal">
@@ -1217,18 +1148,10 @@
           icon.textContent = isVisible ? '+' : '−';
         }
 
-        // 🎯 Bouton flottant : visible dès qu'on a scrollé, ramène aux filtres
-        const fabFilters = document.getElementById('fab-filters');
-        function updateFabVisibility() {
-          if (window.scrollY > 350) {
-            fabFilters.classList.add('visible');
-          } else {
-            fabFilters.classList.remove('visible');
-          }
-        }
-        window.addEventListener('scroll', updateFabVisibility, { passive: true });
-        updateFabVisibility();
-
+        // 🎯 Bouton flottant « Filtres » : piloté par le parent (home.html) pour
+        // fonctionner aussi sur mobile, où c'est la page parente qui scrolle
+        // (sur iOS l'iframe s'étend à la hauteur de son contenu et ne scrolle
+        // pas en interne). L'iframe se contente de reporter son état au parent.
         function scrollToFilters() {
           // Ouvre les filtres avancés pour tout afficher (saison / régime / protéine)
           const advancedFilters = document.getElementById('advancedFilters');
@@ -1239,6 +1162,31 @@
           }
           window.scrollTo({ top: 0, behavior: 'smooth' });
         }
+
+        // Reporter au parent le scroll interne (cas desktop : l'iframe scrolle
+        // elle-même) pour qu'il affiche/masque le bouton flottant.
+        window.addEventListener('scroll', () => {
+          window.parent.postMessage({ type: 'EAT_SCROLL', scrollY: window.scrollY }, '*');
+        }, { passive: true });
+
+        // Reporter l'ouverture/fermeture des modales pour masquer le bouton.
+        const _modalEls = [
+          document.getElementById('recipeModal'),
+          document.getElementById('planningModal'),
+        ].filter(Boolean);
+        function reportModalState() {
+          const anyOpen = _modalEls.some((m) => m.classList.contains('active'));
+          window.parent.postMessage({ type: 'EAT_MODAL', open: anyOpen }, '*');
+        }
+        const _modalObserver = new MutationObserver(reportModalState);
+        _modalEls.forEach((m) =>
+          _modalObserver.observe(m, { attributes: true, attributeFilter: ['class'] })
+        );
+
+        // Répondre à la demande du bouton flottant du parent.
+        window.addEventListener('message', (e) => {
+          if (e && e.data && e.data.type === 'SCROLL_TO_FILTERS') scrollToFilters();
+        });
 
         // Mettre à jour le compteur de filtres actifs
         function updateFilterCount() {

--- a/home.html
+++ b/home.html
@@ -67,6 +67,17 @@
         </div>
       </div>
     </div>
+    <!-- 🎯 Bouton flottant : revenir aux filtres sans tout remonter (page Repas) -->
+    <button
+      id="fabFilters"
+      class="fab-filters"
+      type="button"
+      aria-label="Aller aux filtres"
+      title="Filtres"
+    >
+      <span class="fab-icon" aria-hidden="true">🔍</span>
+      <span class="fab-label">Filtres</span>
+    </button>
     <script>
       // 🔒 Vérifier la session avant d'afficher l'app
 (function checkSession() {
@@ -87,6 +98,37 @@ const toggleText = document.getElementById("toggleText");
 const toggleIcon = document.getElementById("toggleIcon");
 const coursesFrame = document.getElementById("coursesFrame");
 const eatFrame = document.getElementById("eatFrame");
+
+// 🎯 Bouton flottant « Filtres » (page Repas)
+const fabFilters = document.getElementById("fabFilters");
+const appFaceFront = document.querySelector(".app-face.front");
+let eatScrollY = 0;       // scroll interne de l'iframe (cas desktop)
+let eatModalOpen = false; // une modale est ouverte dans l'iframe eat
+
+function updateFabFilters() {
+  const onEat = !appFlipper.classList.contains("flipped");
+  // Sur mobile/iOS c'est le conteneur parent qui scrolle ; sur desktop c'est
+  // l'iframe (via EAT_SCROLL). On prend le maximum des deux.
+  const scrolled = Math.max(eatScrollY, appFaceFront ? appFaceFront.scrollTop : 0);
+  if (onEat && !eatModalOpen && scrolled > 300) {
+    fabFilters.classList.add("visible");
+  } else {
+    fabFilters.classList.remove("visible");
+  }
+}
+if (appFaceFront) {
+  appFaceFront.addEventListener("scroll", updateFabFilters, { passive: true });
+}
+fabFilters.addEventListener("click", () => {
+  // Remonter le conteneur parent (mobile) et demander à l'iframe de remonter
+  // + d'ouvrir les filtres avancés (desktop).
+  if (appFaceFront) appFaceFront.scrollTo({ top: 0, behavior: "smooth" });
+  try {
+    eatFrame.contentWindow.postMessage({ type: "SCROLL_TO_FILTERS" }, "*");
+  } catch (e) {
+    console.error("Error sending SCROLL_TO_FILTERS to eat iframe:", e);
+  }
+});
 
 // 🎯 COMMUNICATION INTER-IFRAMES via postMessage
 // Écouter les messages des iframes enfants
@@ -114,6 +156,16 @@ window.addEventListener("message", (event) => {
         console.error("Error refreshing courses iframe:", e);
       }
       break;
+    case "EAT_SCROLL":
+      // Scroll interne de l'iframe eat (cas desktop) → maj bouton flottant
+      eatScrollY = event.data.scrollY || 0;
+      updateFabFilters();
+      break;
+    case "EAT_MODAL":
+      // Une modale s'ouvre/ferme dans eat → masquer/afficher le bouton flottant
+      eatModalOpen = !!event.data.open;
+      updateFabFilters();
+      break;
   }
 });
 
@@ -124,6 +176,8 @@ toggleBtn.addEventListener("click", () => {
   const newApp = appFlipper.classList.contains("flipped") ? "courses" : "eat";
   localStorage.setItem('active_app', newApp); // Stocke en local
   updateToggleButton(newApp);
+  eatScrollY = 0;
+  updateFabFilters(); // masque le bouton filtres hors page Repas
  
   // 🎯 Envoyer un message à courses pour afficher la Liste courses (sans recharger l'iframe)
   if (newApp === "courses") {
@@ -167,6 +221,7 @@ window.addEventListener("load", () => {
   } else {
     updateToggleButton("eat");
   }
+  updateFabFilters();
   console.log("✅ FOOD HOME loaded - postMessage communication ready");
 });
 


### PR DESCRIPTION
## Problème

Le bouton flottant « 🔍 Filtres » (ajouté en #26) n'apparaissait **jamais sur mobile**.

En cause : il vivait à l'intérieur de l'iframe `eat.html`. Or sur iOS, une `<iframe>` s'étend à la hauteur de son contenu et ne scrolle **pas** en interne — c'est le conteneur parent (`.app-face`, `overflow:auto`) qui scrolle. Le `window.scrollY` de l'iframe restait donc à `0` et le bouton ne se déclenchait jamais. De plus, `position: fixed` dans une iframe est peu fiable sur iOS.

## Solution

Le bouton est **déplacé dans `home.html`** (page parente), ancré au vrai viewport :

- **Visibilité** pilotée par le scroll réel : scroll du conteneur parent (`.app-face`, cas mobile) **ou** scroll interne de l'iframe reporté via `postMessage` `EAT_SCROLL` (cas desktop) — on prend le maximum des deux.
- **Clic** : remonte le conteneur parent (`scrollTo` fluide) **et** demande à l'iframe (`SCROLL_TO_FILTERS`) d'ouvrir les filtres avancés et de remonter.
- **Masqué** hors page Repas et quand une modale recette/planning est ouverte (état reporté via `EAT_MODAL`, observé par un `MutationObserver` dans `eat.html`).
- Styles déplacés dans `css/home.css`, toujours basés sur les tokens du thème (accent + dark mode).

## Test

Vérifié au navigateur via `home.html` : bouton caché en haut, visible après scroll (`pointer-events:auto`), clic → remontée + ouverture des filtres avancés, masqué à l'ouverture d'une modale et hors page Repas. Aucune erreur JS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqD9prxnyjHX7z3UdLjqQP)_