### PR TITLE
Ferme le menu compte au clic dans la zone app (iframe)

### DIFF
--- a/home.html
+++ b/home.html
@@ -339,6 +339,10 @@ async function logout() {
   document.addEventListener("click", (e) => {
     if (!account.contains(e.target)) menu.classList.remove("open");
   });
+  // Le contenu de l'app est dans des <iframe> : un clic « à côté » s'y produit
+  // et n'atteint pas le document parent. On ferme donc le menu dès que le focus
+  // quitte la fenêtre (clic dans une iframe, changement d'onglet, etc.).
+  window.addEventListener("blur", () => menu.classList.remove("open"));
 
   FoodHomeCloud.onUser(render);
   FoodHomeCloud.init();


### PR DESCRIPTION
## Problème

Le menu du compte Google (avatar → nom/email/déconnexion) ne se fermait pas en cliquant « à côté » : il fallait recliquer précisément sur l'avatar.

## Cause

Le contenu de `home.html` est affiché dans des `<iframe>` (eat/courses). Un clic « à côté » de l'avatar se produit **dans l'iframe** et n'atteint donc jamais le gestionnaire de clic du document parent qui ferme le menu.

## Correctif

On ferme désormais le menu dès que le focus quitte la fenêtre (`window` `blur`) — ce qui couvre le clic dans une iframe (et aussi le changement d'onglet). Le gestionnaire de clic existant reste pour les clics dans la navbar elle-même.

## Test

Vérifié localement (Chromium) : menu ouvert → focus déplacé dans l'iframe → le menu se ferme.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LDQAQXSNKdnKNx43Yr5gkM

---
_Generated by [Claude Code](https://claude.ai/code/session_01LDQAQXSNKdnKNx43Yr5gkM)_