### PR TITLE
Audit : corrige la tempête WebSocket + robustesse de la sync cloud

### DIFF
--- a/cloud.js
+++ b/cloud.js
@@ -111,7 +111,11 @@
     try {
       if (client) await client.auth.signOut();
     } catch (_) {}
-    currentUser = null;
+    // Couper aussi le pont avec la session legacy, sinon la gate PIN considère
+    // l'utilisateur connecté 24 h après une déconnexion Google.
+    localStorage.removeItem("food_home_logged_in");
+    localStorage.removeItem("food_home_login_time");
+    setUser(null);
   }
 
   // ---- Liste de courses partagée --------------------------------------
@@ -150,28 +154,22 @@
     }
   }
 
-  // Abonnement temps réel : cb(items) à chaque changement distant.
-  function subscribeList(cb) {
-    if (!client || !currentUser) return;
+  // Ajoute des items en FUSIONNANT avec l'état cloud (union) : ne perd jamais
+  // les ajouts faits depuis un autre appareil (contrairement à un push brut qui
+  // écraserait toute la liste). Met aussi à jour le localStorage local.
+  async function addItemsMerged(localItems) {
+    if (!client || !currentUser) return localItems;
     try {
-      client
-        .channel("shopping_list_changes")
-        .on(
-          "postgres_changes",
-          {
-            event: "*",
-            schema: "public",
-            table: "shopping_list",
-            filter: "id=eq." + LIST_ID,
-          },
-          (payload) => {
-            const items = payload && payload.new ? payload.new.items : null;
-            if (Array.isArray(items)) cb(items);
-          }
-        )
-        .subscribe();
+      const cloud = await pullList();
+      const set = new Set(localItems || []);
+      (cloud || []).forEach((i) => set.add(i));
+      const merged = [...set];
+      await pushList(merged);
+      localStorage.setItem(SHOPPING_KEY, JSON.stringify(merged));
+      return merged;
     } catch (e) {
-      console.warn("⚠️ subscribeList KO :", e);
+      console.warn("⚠️ addItemsMerged KO :", e);
+      return localItems;
     }
   }
 
@@ -185,7 +183,7 @@
     signOut,
     pullList,
     pushList,
-    subscribeList,
+    addItemsMerged,
     SHOPPING_KEY,
   };
 })();

--- a/courses.html
+++ b/courses.html
@@ -2270,28 +2270,25 @@
         });
 
         renderCategories();
-
-        // ☁️ Sync cloud (si connecté Google) — sinon localStorage seul (comportement inchangé)
-        if (window.FoodHomeCloud) {
-          try {
-            await FoodHomeCloud.init();
-            if (FoodHomeCloud.isSignedIn()) {
-              const cloudItems = await FoodHomeCloud.pullList();
-              if (cloudItems) {
-                localStorage.setItem(SHOPPING_KEY, JSON.stringify(cloudItems));
-              }
-              // Temps réel : un autre appareil modifie la liste → on ré-applique.
-              FoodHomeCloud.subscribeList((items) => {
-                localStorage.setItem(SHOPPING_KEY, JSON.stringify(items));
-                applyListFromStorage();
-              });
-            }
-          } catch (e) {
-            console.warn("⚠️ Sync cloud indisponible, mode local :", e);
-          }
-        }
-
+        // Rendu immédiat depuis localStorage : jamais bloqué par le réseau.
         loadFromAPI();
+
+        // ☁️ Sync cloud (si connecté Google), EN ARRIÈRE-PLAN et non bloquant.
+        // Remplace l'ancien WebSocket temps réel (qui provoquait une tempête
+        // d'erreurs de reconnexion) par un rafraîchissement à l'ouverture + au
+        // retour sur l'app (onglet/appareil). Sinon : localStorage seul, inchangé.
+        if (window.FoodHomeCloud) {
+          // onUser se déclenche dès que la session Google est résolue (gère aussi
+          // le retour d'OAuth où la session arrive un instant après le chargement).
+          FoodHomeCloud.onUser((user) => {
+            if (user) refreshListFromCloud();
+          });
+          FoodHomeCloud.init();
+          document.addEventListener("visibilitychange", () => {
+            if (!document.hidden) refreshListFromCloud();
+          });
+          window.addEventListener("focus", refreshListFromCloud);
+        }
 
         // 🎯 ÉCOUTER LES MESSAGES de home.html pour switcher automatiquement
         window.addEventListener("message", (event) => {
@@ -2902,9 +2899,20 @@
       // ============================================
 
       // Load from localStorage
+      // Recharge la liste depuis le cloud (si connecté) puis ré-applique.
+      // Appelé à l'ouverture et au retour sur l'app (visibilitychange / focus).
+      async function refreshListFromCloud() {
+        if (!(window.FoodHomeCloud && FoodHomeCloud.isSignedIn())) return;
+        const items = await FoodHomeCloud.pullList();
+        if (Array.isArray(items)) {
+          localStorage.setItem(SHOPPING_KEY, JSON.stringify(items));
+          applyListFromStorage();
+        }
+      }
+
       // Ré-applique intégralement la liste du localStorage (adds ET removes).
-      // Utilisé par la sync temps réel : on remet toutes les sélections à
-      // false puis loadFromAPI recoche celles présentes dans le stockage.
+      // On remet toutes les sélections à false puis loadFromAPI recoche celles
+      // présentes dans le stockage.
       function applyListFromStorage() {
         Object.keys(selections).forEach((k) =>
           Object.keys(selections[k]).forEach((i) => (selections[k][i] = false))

--- a/eat.html
+++ b/eat.html
@@ -899,9 +899,10 @@
           // Sauvegarder en localStorage (source unique)
           localStorage.setItem(SHOPPING_KEY, JSON.stringify(finalList));
 
-          // Sync cloud (si connecté Google) — non bloquant
+          // Sync cloud (si connecté Google) — fusion avec l'état distant pour ne
+          // pas écraser les items ajoutés depuis un autre appareil. Non bloquant.
           if (window.FoodHomeCloud && FoodHomeCloud.isSignedIn()) {
-            FoodHomeCloud.pushList(finalList);
+            FoodHomeCloud.addItemsMerged(finalList);
           }
 
           // Notifier le parent pour refresh de l'iframe courses
@@ -1031,9 +1032,10 @@
           // Sauvegarder en localStorage (source unique)
           localStorage.setItem(SHOPPING_KEY, JSON.stringify(finalList));
 
-          // Sync cloud (si connecté Google) — non bloquant
+          // Sync cloud (si connecté Google) — fusion avec l'état distant pour ne
+          // pas écraser les items ajoutés depuis un autre appareil. Non bloquant.
           if (window.FoodHomeCloud && FoodHomeCloud.isSignedIn()) {
-            FoodHomeCloud.pushList(finalList);
+            FoodHomeCloud.addItemsMerged(finalList);
           }
 
           // Notifier le parent pour refresh de l'iframe courses

--- a/sw.js
+++ b/sw.js
@@ -15,7 +15,7 @@
   Bumper CACHE_VERSION invalide l'ancien cache au prochain déploiement.
 */
 
-const CACHE_VERSION = "food-home-v2";
+const CACHE_VERSION = "food-home-v3";
 
 // Ressources de base pré-mises en cache à l'installation (coquille + données).
 const CORE_ASSETS = [
@@ -83,7 +83,10 @@ self.addEventListener("fetch", (event) => {
         // Copie en cache uniquement les réponses valides.
         if (response && response.status === 200 && response.type === "basic") {
           const copy = response.clone();
-          caches.open(CACHE_VERSION).then((cache) => cache.put(request, copy));
+          caches
+            .open(CACHE_VERSION)
+            .then((cache) => cache.put(request, copy))
+            .catch(() => {}); // quota plein, etc. : on ignore silencieusement
         }
         return response;
       })


### PR DESCRIPTION
## Contexte

Audit du code de sync/PWA suite aux erreurs console signalées (tempête de reconnexions WebSocket Realtime).

## Bug principal — console inondée
- **Supprime l'abonnement Realtime WebSocket** (`cloud.js` `subscribeList`) : en cas d'échec (table absente de la publication `supabase_realtime`, Realtime non activé), `supabase-js` se reconnectait **en boucle** → des dizaines d'erreurs `WebSocket connection failed`.
- Remplacé dans `courses.html` par un **rafraîchissement à l'ouverture + au retour sur l'app** (`visibilitychange` / `focus`) : même bénéfice cross-appareil, **sans WebSocket, sans spam, sans config Supabase supplémentaire**.

## Robustesse / intégrité des données (issues de l'audit)
- **Rendu non bloquant** (`courses.html`) : la liste s'affiche **immédiatement depuis localStorage** avant tout appel réseau (plus de checkmarks bloqués quand le cloud est lent/injoignable). Le pull est piloté par `onUser` (gère le retour d'OAuth où la session arrive juste après le chargement).
- **Plus de clobber multi-appareils** : `cloud.js` `addItemsMerged()` — `eat.html` fusionne avec l'état cloud (**union**) au lieu d'un push brut → n'écrase plus les ajouts faits depuis un autre appareil.
- **`signOut()`** coupe aussi la session legacy (`food_home_logged_in`) via `setUser(null)` → plus de « connecté » fantôme 24 h après déconnexion Google.
- **`sw.js`** : `catch` sur `cache.put` (quota plein) + bump cache **v3**.

## Vérifié sain (non modifié)
Aucune référence pendante aux boutons supprimés ; le SW n'intercepte que le même-origine GET (jamais Supabase) ; la logique saisonnière est correcte.

## Test
Console capturée sur les 4 pages : aucune erreur JS réelle (seuls artefacts sandbox : polices Google + iframes clean-URL en local). `subscribeList` totalement retiré → tempête WebSocket **désormais impossible**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LDQAQXSNKdnKNx43Yr5gkM

---
_Generated by [Claude Code](https://claude.ai/code/session_01LDQAQXSNKdnKNx43Yr5gkM)_