### PR TITLE
Logo navbar sobre (fin de l'emoji 🏠) + correction warning PWA

### DIFF
--- a/courses.html
+++ b/courses.html
@@ -14,6 +14,7 @@
 
     <!-- Mode plein écran (masquer la barre Safari) -->
     <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="mobile-web-app-capable" content="yes" />
 
     <!-- Couleur de la barre de statut -->
     <meta

--- a/css/home.css
+++ b/css/home.css
@@ -58,13 +58,22 @@ body {
   font-weight: var(--font-weight-extrabold);
   letter-spacing: -0.02em;
 }
-.navbar-brand span:first-child {
-  font-size: 32px;
-  animation: bounce 2s ease-in-out infinite;
+/* Logo : petit badge maison (repris de l'icône PWA), sobre, sans animation */
+.brand-mark {
+  width: 34px;
+  height: 34px;
+  flex: 0 0 auto;
+  border-radius: 9px;
+  background: linear-gradient(135deg, #4f8cff 0%, #3b82f6 100%);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 2px 6px rgb(from #3b82f6 r g b / 0.35);
 }
-@keyframes bounce {
-  0%, 100% { transform: translateY(0); }
-  50% { transform: translateY(-4px); }
+.brand-mark svg {
+  width: 62%;
+  height: 62%;
+  display: block;
 }
 .navbar-brand span:last-child {
   background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
@@ -208,8 +217,9 @@ iframe {
   .navbar-brand {
     font-size: 22px;
   }
-  .navbar-brand span:first-child {
-    font-size: 28px;
+  .brand-mark {
+    width: 30px;
+    height: 30px;
   }
   .navbar-controls {
     width: 100%;
@@ -242,8 +252,9 @@ iframe {
     font-size: 20px;
     gap: 10px;
   }
-  .navbar-brand span:first-child {
-    font-size: 24px;
+  .brand-mark {
+    width: 28px;
+    height: 28px;
   }
   .toggle-btn,
   .logout-btn {

--- a/eat.html
+++ b/eat.html
@@ -13,6 +13,7 @@
     
     <!-- Mode plein écran (masquer la barre Safari) -->
     <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="mobile-web-app-capable" content="yes">
     
     <!-- Couleur de la barre de statut -->
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">

--- a/home.html
+++ b/home.html
@@ -13,6 +13,7 @@
     
     <!-- Mode plein écran (masquer la barre Safari) -->
     <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="mobile-web-app-capable" content="yes">
     
     <!-- Couleur de la barre de statut -->
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
@@ -68,7 +69,11 @@
     <!-- Navigation Bar -->
     <div class="navbar">
       <div class="navbar-brand">
-        <span>🏠</span>
+        <span class="brand-mark" aria-hidden="true">
+          <svg viewBox="0 0 512 512" role="img" aria-label="FOOD HOME">
+            <path fill="#fff" fill-rule="evenodd" d="M256 150 L392 268 L344 268 L344 400 L168 400 L168 268 L120 268 Z M256 300 m-46 0 a46 46 0 1 0 92 0 a46 46 0 1 0 -92 0 Z"/>
+          </svg>
+        </span>
         <span>FOOD HOME</span>
       </div>
       <div class="navbar-controls">

--- a/index.html
+++ b/index.html
@@ -12,6 +12,7 @@
     
     <!-- Mode plein écran (masquer la barre Safari) -->
     <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="mobile-web-app-capable" content="yes">
     
     <!-- Couleur de la barre de statut -->
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">


### PR DESCRIPTION
## Changements

- **Logo navbar** (`home.html` + `css/home.css`) : l'emoji maison 🏠 **animé (bounce)**, jugé kitsch, est remplacé par un **petit badge maison en SVG** repris de l'icône PWA (maison blanche sur bleu de marque), **sans animation**. Rendu propre en thème **clair et sombre**, tailles responsive (34 → 30 → 28 px).
- **Warning PWA** : ajout de `<meta name="mobile-web-app-capable" content="yes">` à côté de la variante Apple sur les **4 pages** → supprime le dernier avertissement de dépréciation en console.

## Test
Vérifié localement (Chromium) : rendu du logo en clair et sombre, cohérent avec l'icône installée.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LDQAQXSNKdnKNx43Yr5gkM

---
_Generated by [Claude Code](https://claude.ai/code/session_01LDQAQXSNKdnKNx43Yr5gkM)_