### PR TITLE
Bump du cache service worker v3 → v4 (purge forcée)

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -15,7 +15,7 @@
   Bumper CACHE_VERSION invalide l'ancien cache au prochain déploiement.
 */
 
-const CACHE_VERSION = "food-home-v3";
+const CACHE_VERSION = "food-home-v4";
 
 // Ressources de base pré-mises en cache à l'installation (coquille + données).
 const CORE_ASSETS = [


### PR DESCRIPTION
## Objectif

Forcer chaque client (navigateur + PWA installée) à **invalider l'ancien cache** et à re-télécharger les assets au prochain chargement, pour garantir la récupération des dernières versions — notamment `eat.html` (aperçu carte du planning).

## Changement
- `sw.js` : `CACHE_VERSION` `food-home-v3` → `food-home-v4`. Au prochain chargement, le handler `activate` supprime les anciens caches et le nouveau SW prend le contrôle (`skipWaiting` + `clients.claim`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LDQAQXSNKdnKNx43Yr5gkM

---
_Generated by [Claude Code](https://claude.ai/code/session_01LDQAQXSNKdnKNx43Yr5gkM)_